### PR TITLE
Removing changing gas test

### DIFF
--- a/test/integration-tests/gas-tests/NFTX.gas.test.ts
+++ b/test/integration-tests/gas-tests/NFTX.gas.test.ts
@@ -30,23 +30,6 @@ describe('NFTX Gas Tests', () => {
     planner = new RoutePlanner()
   })
 
-  it('gas: buyAndRedeem w/ random selection', async () => {
-    const value = expandTo18DecimalsBN(4)
-    const numCovens = 2
-    const calldata = nftxZapInterface.encodeFunctionData('buyAndRedeem', [
-      NFTX_COVEN_VAULT_ID,
-      numCovens,
-      [],
-      [WETH.address, '0xd89b16331f39ab3878daf395052851d3ac8cf3cd'],
-      alice.address,
-    ])
-
-    planner.addCommand(CommandType.NFTX, [value.toString(), calldata])
-    const { commands, inputs } = planner
-
-    await snapshotGasCost(router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE, { value }))
-  })
-
   it('gas: buyAndRedeem w/ specific selection', async () => {
     const value = expandTo18DecimalsBN(4)
     const numCovens = 2

--- a/test/integration-tests/gas-tests/__snapshots__/NFTX.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/NFTX.gas.test.ts.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NFTX Gas Tests gas: buyAndRedeem w/ random selection 1`] = `
-Object {
-  "calldataByteLength": 676,
-  "gasUsed": 503952,
-}
-`;
-
 exports[`NFTX Gas Tests gas: buyAndRedeem w/ specific selection 1`] = `
 Object {
   "calldataByteLength": 740,


### PR DESCRIPTION
Closes #110 

For clarity: not removing the regular test of this functionality, which is still in NFTX.test.ts. I am only removing the _gas_ test because depending which "random" token gets bought the gas costs change making the gas somewhat non-deterministic across PRs