### PR TITLE
feat: add lite profile

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,4 +11,7 @@ fs_permissions = [{ access = "read", path = "./script/deployParameters/"}]
 line_length = 120
 quote_style = 'single'
 
+[profile.lite.optimizer_details.yulDetails]
+optimizerSteps = ''
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
For quick testing, add FOUNDRY_PROFILE=lite to get ~8s compilation times instead of ~45s