### PR TITLE
fix: relax node engine reqs to allow 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "!artifacts/contracts/base/**/*"
   ],
   "engines": {
-    "node": "^16"
+    "node": ">=14"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",


### PR DESCRIPTION
This will allow the universal-router-sdk to be installed in projects still using node@14 (see https://github.com/Uniswap/universal-router-sdk/issues/85).