### PR TITLE
Fix typos and misleading comments

### DIFF
--- a/contracts/base/RouterImmutables.sol
+++ b/contracts/base/RouterImmutables.sol
@@ -70,13 +70,13 @@ contract RouterImmutables {
     /// @dev The address of UniswapV2Factory
     address internal immutable UNISWAP_V2_FACTORY;
 
-    /// @dev The address of UniswapV2Pair initcodehash
+    /// @dev The bytes corresponding to UniswapV2Pair initcodehash
     bytes32 internal immutable UNISWAP_V2_PAIR_INIT_CODE_HASH;
 
     /// @dev The address of UniswapV3Factory
     address internal immutable UNISWAP_V3_FACTORY;
 
-    /// @dev The address of UniswapV3Pool initcodehash
+    /// @dev The bytes corresponding to UniswapV3Pool initcodehash
     bytes32 internal immutable UNISWAP_V3_POOL_INIT_CODE_HASH;
 
     constructor(RouterParameters memory params) {

--- a/contracts/interfaces/IUniversalRouter.sol
+++ b/contracts/interfaces/IUniversalRouter.sol
@@ -12,10 +12,10 @@ interface IUniversalRouter is IRewardsCollector, IERC721Receiver, IERC1155Receiv
     /// @notice Thrown when attempting to send ETH directly to the contract
     error ETHNotAccepted();
 
-    /// @notice Thrown executing commands with an expired deadline
+    /// @notice Thrown when executing commands with an expired deadline
     error TransactionDeadlinePassed();
 
-    /// @notice Thrown executing commands with an expired deadline
+    /// @notice Thrown when attempting to execute commands and an incorrect number of inputs are provided
     error LengthMismatch();
 
     /// @notice Executes encoded commands along with provided inputs. Reverts if deadline has expired.


### PR DESCRIPTION
This commit fixes a few typos and misleading comments.