### PR TITLE
Prefer using calldata instead of memory

### DIFF
--- a/contracts/UniversalRouter.sol
+++ b/contracts/UniversalRouter.sol
@@ -37,7 +37,7 @@ contract UniversalRouter is RouterImmutables, IUniversalRouter, Dispatcher, Rewa
         for (uint256 commandIndex = 0; commandIndex < numCommands;) {
             bytes1 command = commands[commandIndex];
 
-            bytes memory input = inputs[commandIndex];
+            bytes calldata input = inputs[commandIndex];
 
             (success, output) = dispatch(command, input);
 

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 
 import {V2SwapRouter} from '../modules/uniswap/v2/V2SwapRouter.sol';
 import {V3SwapRouter} from '../modules/uniswap/v3/V3SwapRouter.sol';
+import {BytesLib} from '../modules/uniswap/v3/BytesLib.sol';
 import {Payments} from '../modules/Payments.sol';
 import {RouterImmutables} from '../base/RouterImmutables.sol';
 import {Callbacks} from '../base/Callbacks.sol';
@@ -16,6 +17,7 @@ import {ICryptoPunksMarket} from '../interfaces/external/ICryptoPunksMarket.sol'
 /// @title Decodes and Executes Commands
 /// @notice Called by the UniversalRouter contract to efficiently decode and execute a singular command
 abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks {
+    using BytesLib for bytes;
     using Recipient for address;
 
     error InvalidCommandType(uint256 commandType);
@@ -38,13 +40,15 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
                 // 0x00 <= command < 0x08
                 if (command < 0x08) {
                     if (command == Commands.V3_SWAP_EXACT_IN) {
-                        (address recipient, uint256 amountIn, uint256 amountOutMin, bytes memory path, bool payerIsUser)
+                        (address recipient, uint256 amountIn, uint256 amountOutMin, , bool payerIsUser)
                         = abi.decode(inputs, (address, uint256, uint256, bytes, bool));
+                        bytes calldata path = inputs.toBytes(3);
                         address payer = payerIsUser ? msg.sender : address(this);
                         v3SwapExactInput(recipient.map(), amountIn, amountOutMin, path, payer);
                     } else if (command == Commands.V3_SWAP_EXACT_OUT) {
-                        (address recipient, uint256 amountOut, uint256 amountInMax, bytes memory path, bool payerIsUser)
+                        (address recipient, uint256 amountOut, uint256 amountInMax, , bool payerIsUser)
                         = abi.decode(inputs, (address, uint256, uint256, bytes, bool));
+                        bytes calldata path = inputs.toBytes(3);
                         address payer = payerIsUser ? msg.sender : address(this);
                         v3SwapExactOutput(recipient.map(), amountOut, amountInMax, path, payer);
                     } else if (command == Commands.PERMIT2_TRANSFER_FROM) {
@@ -52,8 +56,9 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
                             abi.decode(inputs, (address, address, uint160));
                         permit2TransferFrom(token, msg.sender, recipient, amount);
                     } else if (command == Commands.PERMIT2_PERMIT_BATCH) {
-                        (IAllowanceTransfer.PermitBatch memory permitBatch, bytes memory data) =
+                        (IAllowanceTransfer.PermitBatch memory permitBatch, ) =
                             abi.decode(inputs, (IAllowanceTransfer.PermitBatch, bytes));
+                        bytes calldata data = inputs.toBytes(1);
                         PERMIT2.permit(msg.sender, permitBatch, data);
                     } else if (command == Commands.SWEEP) {
                         (address token, address recipient, uint256 amountMin) =
@@ -78,9 +83,10 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
                             address recipient,
                             uint256 amountIn,
                             uint256 amountOutMin,
-                            address[] memory path,
+                            /* address[] memory path */,
                             bool payerIsUser
                         ) = abi.decode(inputs, (address, uint256, uint256, address[], bool));
+                        address[] calldata path = inputs.toAddressArray(3);
                         address payer = payerIsUser ? msg.sender : address(this);
                         v2SwapExactInput(recipient.map(), amountIn, amountOutMin, path, payer);
                     } else if (command == Commands.V2_SWAP_EXACT_OUT) {
@@ -88,14 +94,19 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
                             address recipient,
                             uint256 amountOut,
                             uint256 amountInMax,
-                            address[] memory path,
+                            /* address[] memory path */,
                             bool payerIsUser
                         ) = abi.decode(inputs, (address, uint256, uint256, address[], bool));
+                        address[] calldata path = inputs.toAddressArray(3);
                         address payer = payerIsUser ? msg.sender : address(this);
                         v2SwapExactOutput(recipient.map(), amountOut, amountInMax, path, payer);
                     } else if (command == Commands.PERMIT2_PERMIT) {
-                        (IAllowanceTransfer.PermitSingle memory permitSingle, bytes memory data) =
-                            abi.decode(inputs, (IAllowanceTransfer.PermitSingle, bytes));
+                        // abi.decode(inputs, (IAllowanceTransfer.PermitSingle, bytes));
+                        IAllowanceTransfer.PermitSingle calldata permitSingle;
+                        assembly {
+                            permitSingle := inputs.offset
+                        }
+                        bytes calldata data = inputs.toBytes(6); // PermitSingle takes first 6 slots (0..5)
                         PERMIT2.permit(msg.sender, permitSingle, data);
                     } else if (command == Commands.WRAP_ETH) {
                         (address recipient, uint256 amountMin) = abi.decode(inputs, (address, uint256));
@@ -117,12 +128,14 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
                 // 0x10 <= command < 0x18
                 if (command < 0x18) {
                     if (command == Commands.SEAPORT) {
-                        (uint256 value, bytes memory data) = abi.decode(inputs, (uint256, bytes));
+                        (uint256 value,) = abi.decode(inputs, (uint256, bytes));
+                        bytes calldata data = inputs.toBytes(1);
                         (success, output) = SEAPORT.call{value: value}(data);
                     } else if (command == Commands.LOOKS_RARE_721) {
                         (success, output) = callAndTransfer721(inputs, LOOKS_RARE);
                     } else if (command == Commands.NFTX) {
-                        (uint256 value, bytes memory data) = abi.decode(inputs, (uint256, bytes));
+                        (uint256 value,) = abi.decode(inputs, (uint256, bytes));
+                        bytes calldata data = inputs.toBytes(1);
                         (success, output) = NFTX_ZAP.call{value: value}(data);
                     } else if (command == Commands.CRYPTOPUNKS) {
                         (uint256 punkId, address recipient, uint256 value) =
@@ -152,10 +165,12 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
                     if (command == Commands.X2Y2_721) {
                         (success, output) = callAndTransfer721(inputs, X2Y2);
                     } else if (command == Commands.SUDOSWAP) {
-                        (uint256 value, bytes memory data) = abi.decode(inputs, (uint256, bytes));
+                        (uint256 value,) = abi.decode(inputs, (uint256, bytes));
+                        bytes calldata data = inputs.toBytes(1);
                         (success, output) = SUDOSWAP.call{value: value}(data);
                     } else if (command == Commands.NFT20) {
-                        (uint256 value, bytes memory data) = abi.decode(inputs, (uint256, bytes));
+                        (uint256 value,) = abi.decode(inputs, (uint256, bytes));
+                        bytes calldata data = inputs.toBytes(1);
                         (success, output) = NFT20_ZAP.call{value: value}(data);
                     } else if (command == Commands.X2Y2_1155) {
                         (success, output) = callAndTransfer1155(inputs, X2Y2);
@@ -183,12 +198,13 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
     /// @param protocol The protocol to pass the calldata to
     /// @return success True on success of the command, false on failure
     /// @return output The outputs or error messages, if any, from the command
-    function callAndTransfer721(bytes memory inputs, address protocol)
+    function callAndTransfer721(bytes calldata inputs, address protocol)
         internal
         returns (bool success, bytes memory output)
     {
-        (uint256 value, bytes memory data, address recipient, address token, uint256 id) =
+        (uint256 value, , address recipient, address token, uint256 id) =
             abi.decode(inputs, (uint256, bytes, address, address, uint256));
+        bytes calldata data = inputs.toBytes(1);
         (success, output) = protocol.call{value: value}(data);
         if (success) ERC721(token).safeTransferFrom(address(this), recipient.map(), id);
     }
@@ -198,12 +214,13 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
     /// @param protocol The protocol to pass the calldata to
     /// @return success True on success of the command, false on failure
     /// @return output The outputs or error messages, if any, from the command
-    function callAndTransfer1155(bytes memory inputs, address protocol)
+    function callAndTransfer1155(bytes calldata inputs, address protocol)
         internal
         returns (bool success, bytes memory output)
     {
-        (uint256 value, bytes memory data, address recipient, address token, uint256 id, uint256 amount) =
+        (uint256 value, , address recipient, address token, uint256 id, uint256 amount) =
             abi.decode(inputs, (uint256, bytes, address, address, uint256, uint256));
+        bytes calldata data = inputs.toBytes(1);
         (success, output) = protocol.call{value: value}(data);
         if (success) ERC1155(token).safeTransferFrom(address(this), recipient.map(), id, amount, new bytes(0));
     }

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -28,7 +28,7 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, Callbacks 
     /// @dev 2 masks are used to enable use of a nested-if statement in execution for efficiency reasons
     /// @return success True on success of the command, false on failure
     /// @return output The outputs or error messages, if any, from the command
-    function dispatch(bytes1 commandType, bytes memory inputs) internal returns (bool success, bytes memory output) {
+    function dispatch(bytes1 commandType, bytes calldata inputs) internal returns (bool success, bytes memory output) {
         uint256 command = uint8(commandType & Commands.COMMAND_TYPE_MASK);
 
         success = true;

--- a/contracts/modules/uniswap/v2/V2SwapRouter.sol
+++ b/contracts/modules/uniswap/v2/V2SwapRouter.sol
@@ -15,7 +15,7 @@ abstract contract V2SwapRouter is RouterImmutables, Permit2Payments {
     error V2TooMuchRequested();
     error V2InvalidPath();
 
-    function _v2Swap(address[] memory path, address recipient, address pair) private {
+    function _v2Swap(address[] calldata path, address recipient, address pair) private {
         unchecked {
             if (path.length < 2) revert V2InvalidPath();
 
@@ -54,7 +54,7 @@ abstract contract V2SwapRouter is RouterImmutables, Permit2Payments {
         address recipient,
         uint256 amountIn,
         uint256 amountOutMinimum,
-        address[] memory path,
+        address[] calldata path,
         address payer
     ) internal {
         address firstPair =
@@ -84,7 +84,7 @@ abstract contract V2SwapRouter is RouterImmutables, Permit2Payments {
         address recipient,
         uint256 amountOut,
         uint256 amountInMaximum,
-        address[] memory path,
+        address[] calldata path,
         address payer
     ) internal {
         (uint256 amountIn, address firstPair) =

--- a/contracts/modules/uniswap/v3/BytesLib.sol
+++ b/contracts/modules/uniswap/v3/BytesLib.sol
@@ -6,110 +6,11 @@ pragma solidity ^0.8.0;
 
 library BytesLib {
     error SliceOverflow();
-    error SliceOutOfBounds();
     error ToAddressOverflow();
     error ToAddressOutOfBounds();
     error ToUint24Overflow();
     error ToUint24OutOfBounds();
     error NoSlice();
-
-    // Constants used in slicePool
-    // 43 bytes: token + feeTier + token
-    uint256 internal constant POOL_LENGTH = 43;
-    // Offset from beginning of _bytes to start copying from given that 43 isnt a multiple of 32
-    uint256 internal constant OFFSET = 11; // 43-32=11
-
-    // Constants used in inPlaceSliceToken
-    uint256 internal constant ADDR_AND_FEE_LENGTH = 23;
-
-    /// @notice Slices and returns the first 43 bytes from a bytes string
-    /// @dev 43 bytes = pool (20 bytes) + feeTier (3 bytes) + pool (20 bytes)
-    /// @param _bytes The input bytes string
-    /// @return tempBytes The first 43 bytes of the input bytes string
-    function slicePool(bytes memory _bytes) internal pure returns (bytes memory tempBytes) {
-        if (_bytes.length < POOL_LENGTH) revert SliceOutOfBounds();
-
-        assembly ("memory-safe") {
-            // Get a location of some free memory and store it in tempBytes as
-            // Solidity does for memory variables.
-            tempBytes := mload(0x40)
-
-            // The first word of the slice result is a partial word read from the
-            //  original array - given that 43 is not a multiple of 32. To read it,
-            // we use the length of that partial word (43-32=11) and start copying
-            // that many bytes into the array. The first word we copy will start
-            // with data we don't care about, but the last 11 bytes will
-            // land at the beginning of the contents of the new array. When
-            // we're done copying, we overwrite the full first word with
-            // the actual length of the slice.
-            let copyDestination := add(tempBytes, OFFSET)
-            let endNewBytes := add(copyDestination, POOL_LENGTH)
-
-            let copyFrom := add(_bytes, OFFSET)
-
-            mstore(copyDestination, mload(copyFrom))
-
-            copyDestination := add(copyDestination, 0x20)
-            copyFrom := add(copyFrom, 0x20)
-            mstore(copyDestination, mload(copyFrom))
-
-            mstore(tempBytes, POOL_LENGTH)
-
-            // update free-memory pointer
-            // allocating the array padded to 32 bytes like the compiler does now
-            mstore(0x40, add(tempBytes, 0x60))
-        }
-    }
-
-    /// @notice Removes the first 23 bytes of a bytes string in-place
-    /// @dev 23 bytes = pool (20 bytes) + feeTier (3 bytes)
-    /// @param _bytes The input bytes string to slice
-    function inPlaceSliceToken(bytes memory _bytes, uint256 _length) internal pure {
-        unchecked {
-            if (_length + 31 < _length) revert SliceOverflow();
-            if (ADDR_AND_FEE_LENGTH + _length < ADDR_AND_FEE_LENGTH) revert SliceOverflow();
-            if (_bytes.length < ADDR_AND_FEE_LENGTH + _length) revert SliceOutOfBounds();
-            if (_length == 0) revert NoSlice();
-        }
-
-        assembly ("memory-safe") {
-            // The first word of the slice result is potentially a partial
-            // word read from the original array. To read it, we calculate
-            // the length of that partial word and start copying that many
-            // bytes into the array. The first word we copy will start with
-            // data we don't care about, but the last `lengthmod` bytes will
-            // land at the beginning of the contents of the new array. When
-            // we're done copying, we overwrite the full first word with
-            // the actual length of the slice.
-
-            // 31==0b11111 to extract the final 5 bits of the length of the slice - the amount that
-            // the length in bytes goes over a round number of bytes32
-            let lengthmod := and(_length, 31)
-
-            // The multiplication in the next line is necessary
-            // because when slicing multiples of 32 bytes (lengthmod == 0)
-            // the following copy loop was copying the origin's length
-            // and then ending prematurely not copying everything it should.
-
-            // if the _length is not a multiple of 32, offset is lengthmod
-            // otherwise its 32 (as lengthmod is 0)
-            // offset from beginning of _bytes to start copying from
-            let offset := add(lengthmod, mul(0x20, iszero(lengthmod)))
-
-            // this does calculates where to start copying bytes into
-            // bytes is the location where the bytes array is
-            // byte+offset is the location where copying should start from
-            let copyDestination := add(_bytes, offset)
-            let endNewBytes := add(copyDestination, _length)
-
-            for { let copyFrom := add(copyDestination, ADDR_AND_FEE_LENGTH) } lt(copyDestination, endNewBytes) {
-                copyDestination := add(copyDestination, 0x20)
-                copyFrom := add(copyFrom, 0x20)
-            } { mstore(copyDestination, mload(copyFrom)) }
-
-            mstore(_bytes, _length)
-        }
-    }
 
     /// @notice Returns the address starting at byte `_start`
     /// @dev _bytesLength must equal _bytes.length for this to function correctly
@@ -117,7 +18,7 @@ library BytesLib {
     /// @param _start The starting index of the address
     /// @param _bytesLength The length of _bytes
     /// @return tempAddress The address starting at _start
-    function toAddress(bytes memory _bytes, uint256 _start, uint256 _bytesLength)
+    function toAddress(bytes calldata _bytes, uint256 _start, uint256 _bytesLength)
         internal
         pure
         returns (address tempAddress)
@@ -128,7 +29,7 @@ library BytesLib {
         }
 
         assembly {
-            tempAddress := mload(add(add(_bytes, 0x14), _start))
+            tempAddress := shr(96, calldataload(add(_bytes.offset, _start)))
         }
     }
 
@@ -138,7 +39,7 @@ library BytesLib {
     /// @param _start The starting index of the uint24
     /// @param _bytesLength The length of _bytes
     /// @return tempUint24 The uint24 starting at _start
-    function toUint24(bytes memory _bytes, uint256 _start, uint256 _bytesLength)
+    function toUint24(bytes calldata _bytes, uint256 _start, uint256 _bytesLength)
         internal
         pure
         returns (uint24 tempUint24)
@@ -149,7 +50,23 @@ library BytesLib {
         }
 
         assembly {
-            tempUint24 := mload(add(add(_bytes, 0x3), _start))
+            tempUint24 := shr(232, calldataload(add(_bytes.offset, _start)))
+        }
+    }
+
+    function toBytes(bytes calldata _bytes, uint256 arg) internal pure returns (bytes calldata res) {
+        assembly {
+            let lengthPtr := add(_bytes.offset, calldataload(add(_bytes.offset, mul(0x20, arg))))
+            res.offset := add(lengthPtr, 0x20)
+            res.length := calldataload(lengthPtr)
+        }
+    }
+
+    function toAddressArray(bytes calldata _bytes, uint256 arg) internal pure returns (address[] calldata res) {
+        assembly {
+            let lengthPtr := add(_bytes.offset, calldataload(add(_bytes.offset, mul(0x20, arg))))
+            res.offset := add(lengthPtr, 0x20)
+            res.length := calldataload(lengthPtr)
         }
     }
 }

--- a/contracts/modules/uniswap/v3/V3SwapRouter.sol
+++ b/contracts/modules/uniswap/v3/V3SwapRouter.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {V3Path} from './V3Path.sol';
+import {BytesLib} from './BytesLib.sol';
 import {SafeCast} from '@uniswap/v3-core/contracts/libraries/SafeCast.sol';
 import {IUniswapV3Pool} from '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import {IUniswapV3SwapCallback} from '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol';
@@ -14,6 +15,7 @@ import {ERC20} from 'solmate/src/tokens/ERC20.sol';
 /// @title Router for Uniswap v3 Trades
 abstract contract V3SwapRouter is RouterImmutables, Permit2Payments, IUniswapV3SwapCallback {
     using V3Path for bytes;
+    using BytesLib for bytes;
     using SafeCast for uint256;
 
     error V3InvalidSwap();
@@ -37,7 +39,8 @@ abstract contract V3SwapRouter is RouterImmutables, Permit2Payments, IUniswapV3S
 
     function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external {
         if (amount0Delta <= 0 && amount1Delta <= 0) revert V3InvalidSwap(); // swaps entirely within 0-liquidity regions are not supported
-        (bytes memory path, address payer) = abi.decode(data, (bytes, address));
+        (, address payer) = abi.decode(data, (bytes, address));
+        bytes calldata path = data.toBytes(0);
 
         // because exact output swaps are executed in reverse order, in this case tokenOut is actually tokenIn
         (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
@@ -54,7 +57,7 @@ abstract contract V3SwapRouter is RouterImmutables, Permit2Payments, IUniswapV3S
             // either initiate the next swap or pay
             if (path.hasMultiplePools()) {
                 // this is an intermediate step so the payer is actually this contract
-                path.skipToken();
+                path = path.skipToken();
                 _swap(-amountToPay.toInt256(), msg.sender, path, payer, false);
             } else {
                 if (amountToPay > maxAmountInCached) revert V3TooMuchRequested();
@@ -74,7 +77,7 @@ abstract contract V3SwapRouter is RouterImmutables, Permit2Payments, IUniswapV3S
         address recipient,
         uint256 amountIn,
         uint256 amountOutMinimum,
-        bytes memory path,
+        bytes calldata path,
         address payer
     ) internal {
         // use amountIn == Constants.CONTRACT_BALANCE as a flag to swap the entire balance of the contract
@@ -101,7 +104,7 @@ abstract contract V3SwapRouter is RouterImmutables, Permit2Payments, IUniswapV3S
             // decide whether to continue or terminate
             if (hasMultiplePools) {
                 payer = address(this);
-                path.skipToken();
+                path = path.skipToken();
             } else {
                 amountOut = amountIn;
                 break;
@@ -121,7 +124,7 @@ abstract contract V3SwapRouter is RouterImmutables, Permit2Payments, IUniswapV3S
         address recipient,
         uint256 amountOut,
         uint256 amountInMaximum,
-        bytes memory path,
+        bytes calldata path,
         address payer
     ) internal {
         maxAmountInCached = amountInMaximum;
@@ -137,14 +140,14 @@ abstract contract V3SwapRouter is RouterImmutables, Permit2Payments, IUniswapV3S
 
     /// @dev Performs a single swap for both exactIn and exactOut
     /// For exactIn, `amount` is `amountIn`. For exactOut, `amount` is `-amountOut`
-    function _swap(int256 amount, address recipient, bytes memory path, address payer, bool isExactIn)
+    function _swap(int256 amount, address recipient, bytes calldata path, address payer, bool isExactIn)
         private
         returns (int256 amount0Delta, int256 amount1Delta, bool zeroForOne)
     {
         (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
 
         zeroForOne = isExactIn ? tokenIn < tokenOut : tokenOut < tokenIn;
-
+        
         (amount0Delta, amount1Delta) = IUniswapV3Pool(computePoolAddress(tokenIn, tokenOut, fee)).swap(
             recipient,
             zeroForOne,

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = 'out'
 libs = ['lib']
 via_ir = true
 solc_version = '0.8.17'
-optimizer_runs = 1_000_000
+optimizer_runs = 10_000
 fs_permissions = [{ access = "read", path = "./script/deployParameters/"}]
 
 [fmt]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,7 +11,7 @@ const DEFAULT_COMPILER_SETTINGS = {
     evmVersion: 'istanbul',
     optimizer: {
       enabled: true,
-      runs: 1_000_000,
+      runs: 10_000,
     },
     metadata: {
       bytecodeHash: 'none',

--- a/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
@@ -3,27 +3,27 @@
 exports[`Check Ownership Gas gas: checks ownership after a seaport trade, one NFT 1`] = `
 Object {
   "calldataByteLength": 2212,
-  "gasUsed": 206085,
+  "gasUsed": 201820,
 }
 `;
 
 exports[`Check Ownership Gas gas: checks ownership after a seaport trade, two NFTs 1`] = `
 Object {
   "calldataByteLength": 5028,
-  "gasUsed": 341610,
+  "gasUsed": 331265,
 }
 `;
 
 exports[`Check Ownership Gas gas: does not check ownership after a seaport trade, one NFT 1`] = `
 Object {
   "calldataByteLength": 2052,
-  "gasUsed": 202513,
+  "gasUsed": 198554,
 }
 `;
 
 exports[`Check Ownership Gas gas: just ownership check 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 32964,
+  "gasUsed": 32658,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
@@ -3,27 +3,27 @@
 exports[`Check Ownership Gas gas: checks ownership after a seaport trade, one NFT 1`] = `
 Object {
   "calldataByteLength": 2212,
-  "gasUsed": 201820,
+  "gasUsed": 202090,
 }
 `;
 
 exports[`Check Ownership Gas gas: checks ownership after a seaport trade, two NFTs 1`] = `
 Object {
   "calldataByteLength": 5028,
-  "gasUsed": 331265,
+  "gasUsed": 331941,
 }
 `;
 
 exports[`Check Ownership Gas gas: does not check ownership after a seaport trade, one NFT 1`] = `
 Object {
   "calldataByteLength": 2052,
-  "gasUsed": 198554,
+  "gasUsed": 198839,
 }
 `;
 
 exports[`Check Ownership Gas gas: just ownership check 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 32658,
+  "gasUsed": 32606,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/CryptoPunk.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CryptoPunk.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Cryptopunks purchases 1 cryptopunk gas 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 109648,
+  "gasUsed": 109508,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/CryptoPunk.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CryptoPunk.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Cryptopunks purchases 1 cryptopunk gas 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 109896,
+  "gasUsed": 109648,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Foundation.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Foundation.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Foundation Gas Tests Buy a mental worlds NFT from Foundation gas: token id 32 of mental worlds 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 183803,
+  "gasUsed": 183810,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Foundation.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Foundation.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Foundation Gas Tests Buy a mental worlds NFT from Foundation gas: token id 32 of mental worlds 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 183810,
+  "gasUsed": 183243,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/LooksRare.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/LooksRare.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`LooksRare Gas Tests ERC-721 Purchase gas: buy 1 ERC-721 on looks rare 1`] = `
 Object {
   "calldataByteLength": 1316,
-  "gasUsed": 248814,
+  "gasUsed": 248829,
 }
 `;
 
 exports[`LooksRare Gas Tests ERC-1155 Purchase gas: buy 1 ERC-1155 on looks rare 1`] = `
 Object {
   "calldataByteLength": 1348,
-  "gasUsed": 268839,
+  "gasUsed": 268872,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/LooksRare.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/LooksRare.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`LooksRare Gas Tests ERC-721 Purchase gas: buy 1 ERC-721 on looks rare 1`] = `
 Object {
   "calldataByteLength": 1316,
-  "gasUsed": 248829,
+  "gasUsed": 246740,
 }
 `;
 
 exports[`LooksRare Gas Tests ERC-1155 Purchase gas: buy 1 ERC-1155 on looks rare 1`] = `
 Object {
   "calldataByteLength": 1348,
-  "gasUsed": 268872,
+  "gasUsed": 266752,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/NFT20.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/NFT20.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`NFT20 Buy 3 alphabetties from NFT20 gas: purchases token ids 129, 193, 278 of Alphabetties 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 392380,
+  "gasUsed": 392432,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/NFT20.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/NFT20.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`NFT20 Buy 3 alphabetties from NFT20 gas: purchases token ids 129, 193, 278 of Alphabetties 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 393715,
+  "gasUsed": 392380,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/NFTX.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/NFTX.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`NFTX Gas Tests gas: buyAndRedeem w/ specific selection 1`] = `
 Object {
   "calldataByteLength": 740,
-  "gasUsed": 494043,
+  "gasUsed": 494076,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/NFTX.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/NFTX.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`NFTX Gas Tests gas: buyAndRedeem w/ specific selection 1`] = `
 Object {
   "calldataByteLength": 740,
-  "gasUsed": 494947,
+  "gasUsed": 494043,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -3,48 +3,48 @@
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 39528,
+  "gasUsed": 39203,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 68792,
+  "gasUsed": 68145,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 38502,
+  "gasUsed": 38177,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ETH 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 34093,
+  "gasUsed": 33762,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 46981,
+  "gasUsed": 46662,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 54381,
+  "gasUsed": 53421,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: WRAP_ETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 57598,
+  "gasUsed": 57338,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -3,48 +3,48 @@
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 39203,
+  "gasUsed": 39244,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 68145,
+  "gasUsed": 68285,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 38177,
+  "gasUsed": 38313,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ETH 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 33762,
+  "gasUsed": 33877,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 46662,
+  "gasUsed": 46642,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 53421,
+  "gasUsed": 53613,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: WRAP_ETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 57338,
+  "gasUsed": 57363,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Seaport.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Seaport.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`Seaport Gas Tests gas: fulfillAdvancedOrder 1`] = `
 Object {
   "calldataByteLength": 2052,
-  "gasUsed": 202513,
+  "gasUsed": 198554,
 }
 `;
 
 exports[`Seaport Gas Tests gas: fulfillAvailableAdvancedOrders 1 orders 1`] = `
 Object {
   "calldataByteLength": 4708,
-  "gasUsed": 334460,
+  "gasUsed": 324734,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Seaport.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Seaport.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`Seaport Gas Tests gas: fulfillAdvancedOrder 1`] = `
 Object {
   "calldataByteLength": 2052,
-  "gasUsed": 198554,
+  "gasUsed": 198839,
 }
 `;
 
 exports[`Seaport Gas Tests gas: fulfillAvailableAdvancedOrders 1 orders 1`] = `
 Object {
   "calldataByteLength": 4708,
-  "gasUsed": 324734,
+  "gasUsed": 325439,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Sudoswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Sudoswap.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Sudoswap Gas Tests Buy 3 sudolets from sudoswap gas: purchases token ids 80, 35, 93 of Sudolets 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 192678,
+  "gasUsed": 191343,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Sudoswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Sudoswap.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Sudoswap Gas Tests Buy 3 sudolets from sudoswap gas: purchases token ids 80, 35, 93 of Sudolets 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 191343,
+  "gasUsed": 191373,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,77 +3,77 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V2, then V3 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 199537,
+  "gasUsed": 198749,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V3, then V2 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 192091,
+  "gasUsed": 191304,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, different input tokens, each two hop, with batch permit 1`] = `
 Object {
   "calldataByteLength": 1540,
-  "gasUsed": 308729,
+  "gasUsed": 307438,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit 1`] = `
 Object {
   "calldataByteLength": 1220,
-  "gasUsed": 316708,
+  "gasUsed": 315384,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit transfer from batch 1`] = `
 Object {
   "calldataByteLength": 1284,
-  "gasUsed": 318468,
+  "gasUsed": 317421,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, without explicit permit 1`] = `
 Object {
   "calldataByteLength": 900,
-  "gasUsed": 312431,
+  "gasUsed": 311754,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 996,
-  "gasUsed": 182792,
+  "gasUsed": 181694,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 996,
-  "gasUsed": 182567,
+  "gasUsed": 181469,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, exactOut, one hop 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 200225,
+  "gasUsed": 199131,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 190555,
+  "gasUsed": 189460,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 218582,
+  "gasUsed": 217445,
 }
 `;
 
@@ -115,98 +115,98 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn trade, where an output fee is taken 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 130851,
+  "gasUsed": 129877,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 109979,
+  "gasUsed": 109647,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 248400,
+  "gasUsed": 248054,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops, no deadline 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 248148,
+  "gasUsed": 247811,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 180878,
+  "gasUsed": 180540,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops, MSG_SENDER flag 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 180878,
+  "gasUsed": 180540,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 109364,
+  "gasUsed": 109032,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 252887,
+  "gasUsed": 252540,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 182846,
+  "gasUsed": 182507,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 126627,
+  "gasUsed": 125988,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 804,
-  "gasUsed": 131650,
+  "gasUsed": 130691,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, with ETH fee 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 147377,
+  "gasUsed": 146099,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 110308,
+  "gasUsed": 109653,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 772,
-  "gasUsed": 142588,
+  "gasUsed": 141818,
 }
 `;
 
@@ -255,69 +255,69 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 118375,
+  "gasUsed": 117918,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 279758,
+  "gasUsed": 279298,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 194742,
+  "gasUsed": 194250,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 119649,
+  "gasUsed": 119193,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 424204,
+  "gasUsed": 423745,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 316902,
+  "gasUsed": 316410,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 135071,
+  "gasUsed": 134307,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 136417,
+  "gasUsed": 135654,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 248155,
+  "gasUsed": 247376,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 772,
-  "gasUsed": 144592,
+  "gasUsed": 143723,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,77 +3,77 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V2, then V3 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 198749,
+  "gasUsed": 198397,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V3, then V2 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 191304,
+  "gasUsed": 190954,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, different input tokens, each two hop, with batch permit 1`] = `
 Object {
   "calldataByteLength": 1540,
-  "gasUsed": 307438,
+  "gasUsed": 307751,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit 1`] = `
 Object {
   "calldataByteLength": 1220,
-  "gasUsed": 315384,
+  "gasUsed": 315609,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit transfer from batch 1`] = `
 Object {
   "calldataByteLength": 1284,
-  "gasUsed": 317421,
+  "gasUsed": 317696,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, without explicit permit 1`] = `
 Object {
   "calldataByteLength": 900,
-  "gasUsed": 311754,
+  "gasUsed": 311947,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 996,
-  "gasUsed": 181694,
+  "gasUsed": 181474,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 996,
-  "gasUsed": 181469,
+  "gasUsed": 181249,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, exactOut, one hop 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 199131,
+  "gasUsed": 199628,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 189460,
+  "gasUsed": 189179,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 217445,
+  "gasUsed": 217367,
 }
 `;
 
@@ -115,98 +115,98 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn trade, where an output fee is taken 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 129877,
+  "gasUsed": 130209,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 109647,
+  "gasUsed": 109796,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 248054,
+  "gasUsed": 248055,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops, no deadline 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 247811,
+  "gasUsed": 247791,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 180540,
+  "gasUsed": 180618,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops, MSG_SENDER flag 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 180540,
+  "gasUsed": 180618,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 109032,
+  "gasUsed": 109662,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 252540,
+  "gasUsed": 253383,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 182507,
+  "gasUsed": 183244,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 125988,
+  "gasUsed": 126160,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 804,
-  "gasUsed": 130691,
+  "gasUsed": 131400,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, with ETH fee 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 146099,
+  "gasUsed": 146988,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 109653,
+  "gasUsed": 109824,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 772,
-  "gasUsed": 141818,
+  "gasUsed": 142421,
 }
 `;
 
@@ -255,69 +255,69 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 117918,
+  "gasUsed": 117422,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 279298,
+  "gasUsed": 277260,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 194250,
+  "gasUsed": 193016,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 119193,
+  "gasUsed": 118997,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 423745,
+  "gasUsed": 422364,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 316410,
+  "gasUsed": 315654,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 134307,
+  "gasUsed": 133834,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 135654,
+  "gasUsed": 135481,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 247376,
+  "gasUsed": 246981,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 772,
-  "gasUsed": 143723,
+  "gasUsed": 143665,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalRouter.gas.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniversalRouter Gas Tests gas: bytecode size 1`] = `17253`;
+exports[`UniversalRouter Gas Tests gas: bytecode size 1`] = `23258`;
 
 exports[`UniversalRouter Gas Tests trading for NFTs gas: ERC20 --> ETH --> Seaport NFT 1`] = `
 Object {
   "calldataByteLength": 2500,
-  "gasUsed": 299633,
+  "gasUsed": 300617,
 }
 `;
 
 exports[`UniversalRouter Gas Tests trading for NFTs gas: ETH --> Seaport NFT 1`] = `
 Object {
   "calldataByteLength": 2052,
-  "gasUsed": 198554,
+  "gasUsed": 198839,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalRouter.gas.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniversalRouter Gas Tests gas: bytecode size 1`] = `17259`;
+exports[`UniversalRouter Gas Tests gas: bytecode size 1`] = `17253`;
 
 exports[`UniversalRouter Gas Tests trading for NFTs gas: ERC20 --> ETH --> Seaport NFT 1`] = `
 Object {
   "calldataByteLength": 2500,
-  "gasUsed": 304247,
+  "gasUsed": 299633,
 }
 `;
 
 exports[`UniversalRouter Gas Tests trading for NFTs gas: ETH --> Seaport NFT 1`] = `
 Object {
   "calldataByteLength": 2052,
-  "gasUsed": 202513,
+  "gasUsed": 198554,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
@@ -7,32 +7,32 @@ Object {
 }
 `;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1179223`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1175550`;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1216624`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1211820`;
 
 exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps SwapRouter02 1`] = `1172945`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3285667`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3276129`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3452670`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3438045`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps SwapRouter02 1`] = `278117`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4390673`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4377594`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4612547`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4592692`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions SwapRouter02 1`] = `4470036`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `540861`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `538982`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `541179`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `539300`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap SwapRouter02 1`] = `520492`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `314663`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `313617`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `314599`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `313553`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap SwapRouter02 1`] = `278117`;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
@@ -7,32 +7,32 @@ Object {
 }
 `;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1175550`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1168538`;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1211820`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1202506`;
 
 exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps SwapRouter02 1`] = `1172945`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3276129`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3257162`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3438045`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3408720`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps SwapRouter02 1`] = `278117`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4377594`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4349997`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4592692`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4551287`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions SwapRouter02 1`] = `4470036`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `538982`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `535533`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `539300`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `535851`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap SwapRouter02 1`] = `520492`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `313617`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `311201`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `313553`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `311137`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap SwapRouter02 1`] = `278117`;

--- a/test/integration-tests/gas-tests/__snapshots__/X2Y2.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/X2Y2.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`X2Y2 ERC-721 purchase gas: purchases 1 ERC-721 on X2Y2 1`] = `
 Object {
   "calldataByteLength": 2212,
-  "gasUsed": 214562,
+  "gasUsed": 210707,
 }
 `;
 
 exports[`X2Y2 ERC-1155 purchase gas: purchases 1 ERC-1155 on X2Y2 1`] = `
 Object {
   "calldataByteLength": 2276,
-  "gasUsed": 215775,
+  "gasUsed": 211826,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/X2Y2.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/X2Y2.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`X2Y2 ERC-721 purchase gas: purchases 1 ERC-721 on X2Y2 1`] = `
 Object {
   "calldataByteLength": 2212,
-  "gasUsed": 214553,
+  "gasUsed": 214562,
 }
 `;
 
 exports[`X2Y2 ERC-1155 purchase gas: purchases 1 ERC-1155 on X2Y2 1`] = `
 Object {
   "calldataByteLength": 2276,
-  "gasUsed": 215766,
+  "gasUsed": 215775,
 }
 `;


### PR DESCRIPTION
Sometimes it's a lot cheaper in terms of gas, sometimes it's a bit.

I was made to decrease `runs` setting in hardhat config due slightly increased bytecode size (out of 24kb limit).