### PR TITLE
NPM beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.2.2",
+  "version": "1.4.0-beta.0",
   "keywords": [
     "uniswap",
     "router",


### PR DESCRIPTION
NPM version `1.4.0-beta.0` so I can start to update the SDK

Skipping 1.3.0 as that was used to publish URv1.1 on [another branch](https://github.com/Uniswap/universal-router/tree/deployed-commit-URv1.1/contracts)