### PR TITLE
tighten pragma on UniswapV2Library

### DIFF
--- a/contracts/modules/uniswap/v2/UniswapV2Library.sol
+++ b/contracts/modules/uniswap/v2/UniswapV2Library.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.0;
 
 import {IUniswapV2Pair} from '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';
 


### PR DESCRIPTION
because the logic in `getAmount{Out,In}` is technically vulnerable to overflow, we should tighten the pragma on this library to only work with solidity >=0.8. only effects 3rd party use, as we're using solidity 0.8.17