### PR TITLE
Decode everything in `calldata`

### DIFF
--- a/contracts/modules/Permit2Payments.sol
+++ b/contracts/modules/Permit2Payments.sol
@@ -24,7 +24,7 @@ abstract contract Permit2Payments is Payments {
 
     /// @notice Performs a batch transferFrom on Permit2
     /// @param batchDetails An array detailing each of the transfers that should occur
-    function permit2TransferFrom(IAllowanceTransfer.AllowanceTransferDetails[] memory batchDetails, address owner)
+    function permit2TransferFrom(IAllowanceTransfer.AllowanceTransferDetails[] calldata batchDetails, address owner)
         internal
     {
         uint256 batchLength = batchDetails.length;

--- a/contracts/modules/uniswap/v3/V3SwapRouter.sol
+++ b/contracts/modules/uniswap/v3/V3SwapRouter.sol
@@ -39,8 +39,12 @@ abstract contract V3SwapRouter is RouterImmutables, Permit2Payments, IUniswapV3S
 
     function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external {
         if (amount0Delta <= 0 && amount1Delta <= 0) revert V3InvalidSwap(); // swaps entirely within 0-liquidity regions are not supported
-        (, address payer) = abi.decode(data, (bytes, address));
         bytes calldata path = data.toBytes(0);
+        address payer;
+        assembly {
+            // equivalent: abi.decode(data, (bytes, address))
+            payer := calldataload(add(data.offset, 0x20))
+        }
 
         // because exact output swaps are executed in reverse order, in this case tokenOut is actually tokenIn
         (address tokenIn, uint24 fee, address tokenOut) = path.decodeFirstPool();

--- a/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
@@ -3,34 +3,34 @@
 exports[`Check Ownership Gas gas: balance check ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 39837,
+  "gasUsed": 39810,
 }
 `;
 
 exports[`Check Ownership Gas gas: checks ownership after a seaport trade, one NFT 1`] = `
 Object {
   "calldataByteLength": 2180,
-  "gasUsed": 185340,
+  "gasUsed": 185230,
 }
 `;
 
 exports[`Check Ownership Gas gas: checks ownership after a seaport trade, two NFTs 1`] = `
 Object {
   "calldataByteLength": 5028,
-  "gasUsed": 294767,
+  "gasUsed": 294631,
 }
 `;
 
 exports[`Check Ownership Gas gas: does not check ownership after a seaport trade, one NFT 1`] = `
 Object {
   "calldataByteLength": 2020,
-  "gasUsed": 182447,
+  "gasUsed": 182372,
 }
 `;
 
 exports[`Check Ownership Gas gas: just ownership check 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 32519,
+  "gasUsed": 32474,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/CryptoPunk.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CryptoPunk.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Cryptopunks purchases 1 cryptopunk gas 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 109587,
+  "gasUsed": 109543,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Element.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Element.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Element Market gas tests gas: purchases open order 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 123947,
+  "gasUsed": 123911,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Foundation.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Foundation.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Foundation Gas Tests Buy a mental worlds NFT from Foundation gas: token id 32 of mental worlds 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 182987,
+  "gasUsed": 182958,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/LooksRareV2.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/LooksRareV2.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`LooksRareV2 Gas Test Bulk Buy Buys 2 721s 1`] = `
 Object {
   "calldataByteLength": 2884,
-  "gasUsed": 335502,
+  "gasUsed": 335466,
 }
 `;
 
 exports[`LooksRareV2 Gas Test Single Buy Buy a 721 1`] = `
 Object {
   "calldataByteLength": 1508,
-  "gasUsed": 189890,
+  "gasUsed": 189854,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/NFT20.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/NFT20.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`NFT20 Buy 3 alphabetties from NFT20 gas: purchases token ids 129, 193, 278 of Alphabetties 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 392225,
+  "gasUsed": 392189,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/NFTX.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/NFTX.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`NFTX Gas Tests gas: buyAndRedeem w/ specific selection 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 574870,
+  "gasUsed": 574837,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -3,55 +3,55 @@
 exports[`Payments Gas Tests Individual Command Tests gas: APPROVE_ERC20 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 53851,
+  "gasUsed": 53803,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 39235,
+  "gasUsed": 39208,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 67925,
+  "gasUsed": 67887,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 38248,
+  "gasUsed": 38224,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ETH 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 33821,
+  "gasUsed": 33791,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 46765,
+  "gasUsed": 46776,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 53127,
+  "gasUsed": 53110,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: WRAP_ETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 57425,
+  "gasUsed": 57384,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/SeaportV1_4.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/SeaportV1_4.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`Seaport v1.4 Gas Tests ERC20 -> NFT gas: fulfillAdvancedOrder 1`] = `
 Object {
   "calldataByteLength": 2532,
-  "gasUsed": 237135,
+  "gasUsed": 236943,
 }
 `;
 
 exports[`Seaport v1.4 Gas Tests ETH -> NFT gas: fulfillAdvancedOrder 1`] = `
 Object {
   "calldataByteLength": 2020,
-  "gasUsed": 182447,
+  "gasUsed": 182372,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/SeaportV1_5.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/SeaportV1_5.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`Seaport v1.5 Gas Tests ETH -> NFT gas: fulfillAdvancedOrder 1`] = `
 Object {
   "calldataByteLength": 2020,
-  "gasUsed": 152097,
+  "gasUsed": 152034,
 }
 `;
 
 exports[`Seaport v1.5 Gas Tests ETH -> NFT gas: fulfillAvailableAdvancedOrders 2 orders 1`] = `
 Object {
   "calldataByteLength": 4644,
-  "gasUsed": 288379,
+  "gasUsed": 288313,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Sudoswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Sudoswap.gas.test.ts.snap
@@ -3,20 +3,20 @@
 exports[`Sudoswap Gas Tests ERC20 -> NFT gas: purchases NFTs with FRAX ERC20 token already approved 1`] = `
 Object {
   "calldataByteLength": 1380,
-  "gasUsed": 289920,
+  "gasUsed": 289775,
 }
 `;
 
 exports[`Sudoswap Gas Tests ERC20 -> NFT gas: purchases tokens 2402, 2509 of Based Ghoul with FRAX ERC20 token 1`] = `
 Object {
   "calldataByteLength": 1508,
-  "gasUsed": 311549,
+  "gasUsed": 311366,
 }
 `;
 
 exports[`Sudoswap Gas Tests ETH -> NFT gas: purchases token ids 173, 239, 240 of Sudolets 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 201657,
+  "gasUsed": 201591,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,105 +3,105 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, both fail but the transaction succeeds 1`] = `
 Object {
   "calldataByteLength": 1764,
-  "gasUsed": 273152,
+  "gasUsed": 270184,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, neither fails 1`] = `
 Object {
   "calldataByteLength": 1764,
-  "gasUsed": 248874,
+  "gasUsed": 245932,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, second sub plan fails 1`] = `
 Object {
   "calldataByteLength": 1764,
-  "gasUsed": 248874,
+  "gasUsed": 245932,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, the first fails 1`] = `
 Object {
   "calldataByteLength": 1764,
-  "gasUsed": 273152,
+  "gasUsed": 270184,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V2, then V3 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 196828,
+  "gasUsed": 195131,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V3, then V2 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 189624,
+  "gasUsed": 187927,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, different input tokens, each two hop, with batch permit 1`] = `
 Object {
   "calldataByteLength": 1540,
-  "gasUsed": 305306,
+  "gasUsed": 302159,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit 1`] = `
 Object {
   "calldataByteLength": 1220,
-  "gasUsed": 313366,
+  "gasUsed": 311575,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit transfer from batch 1`] = `
 Object {
   "calldataByteLength": 1284,
-  "gasUsed": 315444,
+  "gasUsed": 312763,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, without explicit permit 1`] = `
 Object {
   "calldataByteLength": 900,
-  "gasUsed": 309818,
+  "gasUsed": 308079,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 996,
-  "gasUsed": 179794,
+  "gasUsed": 178079,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 996,
-  "gasUsed": 179569,
+  "gasUsed": 177854,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, exactOut, one hop 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 198235,
+  "gasUsed": 196422,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 187631,
+  "gasUsed": 185954,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 200312,
+  "gasUsed": 198466,
 }
 `;
 
@@ -143,98 +143,98 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn trade, where an output fee is taken 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 128824,
+  "gasUsed": 128258,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 109042,
+  "gasUsed": 108504,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 246952,
+  "gasUsed": 245742,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops, no deadline 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 246694,
+  "gasUsed": 245484,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 179686,
+  "gasUsed": 178827,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops, MSG_SENDER flag 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 179686,
+  "gasUsed": 178827,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 109016,
+  "gasUsed": 108398,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 252135,
+  "gasUsed": 250125,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 182300,
+  "gasUsed": 180965,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 125258,
+  "gasUsed": 124741,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 804,
-  "gasUsed": 130417,
+  "gasUsed": 129847,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, with ETH fee 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 138406,
+  "gasUsed": 137825,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 108953,
+  "gasUsed": 108342,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 772,
-  "gasUsed": 127616,
+  "gasUsed": 126978,
 }
 `;
 
@@ -283,69 +283,69 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 117144,
+  "gasUsed": 115975,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 276366,
+  "gasUsed": 272939,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 192426,
+  "gasUsed": 190100,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 118771,
+  "gasUsed": 117502,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 421314,
+  "gasUsed": 418104,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 548,
-  "gasUsed": 315013,
+  "gasUsed": 312765,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 133408,
+  "gasUsed": 132260,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 135107,
+  "gasUsed": 133859,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 242391,
+  "gasUsed": 241123,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 772,
-  "gasUsed": 129590,
+  "gasUsed": 128319,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalRouter.gas.test.ts.snap
@@ -1,24 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniversalRouter Gas Tests gas: bytecode size 1`] = `18307`;
+exports[`UniversalRouter Gas Tests gas: bytecode size 1`] = `16466`;
 
 exports[`UniversalRouter Gas Tests trading for NFTs gas: ERC20 --> ETH --> Seaport NFT 1`] = `
 Object {
   "calldataByteLength": 2468,
-  "gasUsed": 252703,
+  "gasUsed": 252095,
 }
 `;
 
 exports[`UniversalRouter Gas Tests trading for NFTs gas: ETH --> Seaport NFT 1`] = `
 Object {
   "calldataByteLength": 2020,
-  "gasUsed": 152097,
+  "gasUsed": 152034,
 }
 `;
 
 exports[`UniversalRouter Gas Tests trading for NFTs gas: WETH --> ETH --> Seaport NFT 1`] = `
 Object {
   "calldataByteLength": 2308,
-  "gasUsed": 186861,
+  "gasUsed": 186793,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
@@ -7,32 +7,32 @@ Object {
 }
 `;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1162636`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1149839`;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1197018`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1184115`;
 
 exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps SwapRouter02 1`] = `1172945`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3240424`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3202696`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3393845`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3355640`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps SwapRouter02 1`] = `3320620`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4330328`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4280864`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4534102`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4484002`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions SwapRouter02 1`] = `4470036`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `533020`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `527758`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `533338`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `528076`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap SwapRouter02 1`] = `520492`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `310739`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `308360`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `310675`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `308296`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap SwapRouter02 1`] = `278117`;

--- a/test/integration-tests/gas-tests/__snapshots__/X2Y2.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/X2Y2.gas.test.ts.snap
@@ -3,13 +3,13 @@
 exports[`X2Y2 ERC-721 purchase gas: purchases 1 ERC-721 on X2Y2 1`] = `
 Object {
   "calldataByteLength": 2212,
-  "gasUsed": 210135,
+  "gasUsed": 210105,
 }
 `;
 
 exports[`X2Y2 ERC-1155 purchase gas: purchases 1 ERC-1155 on X2Y2 1`] = `
 Object {
   "calldataByteLength": 2276,
-  "gasUsed": 211192,
+  "gasUsed": 211147,
 }
 `;


### PR DESCRIPTION
Replace the rest of `abi.decode` with decoding to `calldata` using inline assembly. Reduce gas and bytecode size.