### PR TITLE
change permit2 gh url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/transmissions11/solmate
 [submodule "lib/permit2"]
 	path = lib/permit2
-	url = git@github.com:Uniswap/permit2.git
+	url = https://github.com/Uniswap/permit2


### PR DESCRIPTION
@hensha256 I could not link the permit2 submodule until I made this change. I then had to `git submodule deinit lib/permit2` followed by `git submodule init`/