### PR TITLE
Pass tests with alternative FORK_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 INFURA_API_KEY=
+FORK_URL=https://mainnet.infura.io/v3/${INFURA_API_KEY}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,4 @@ jobs:
         run: yarn test
         env:
           INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}
+          FORK_URL: https://mainnet.infura.io/v3/${{ secrets.INFURA_API_KEY }}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -28,7 +28,7 @@ export default {
       allowUnlimitedContractSize: false,
       chainId: 1,
       forking: {
-        url: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
+        url: `${process.env.FORK_URL}`,
         blockNumber: 15360000,
       },
     },

--- a/test/integration-tests/shared/mainnetForkHelpers.ts
+++ b/test/integration-tests/shared/mainnetForkHelpers.ts
@@ -108,7 +108,7 @@ export const resetFork = async (block: number = 15360000) => {
     params: [
       {
         forking: {
-          jsonRpcUrl: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
+          jsonRpcUrl: `${process.env.FORK_URL}`,
           blockNumber: block,
         },
       },


### PR DESCRIPTION
@hensha256 I had trouble getting the tests working, apparently because my Infura account doesn't support archive nodes. I had to use the FORK_URL environment variable to set an alchemy url.

This worked for `forge test` but not `hardhat test`. I had to change a couple of places in the code where an Infura url was hardcoded as the fork url.

After these changes, all the tests work perfectly, both forge and hardhat.