### PR TITLE
Add VS Code Devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM restlessronin/foundry AS foundry
+
+FROM node:18-bullseye AS node
+
+COPY --from=foundry /usr/local/bin/forge /usr/local/bin/forge
+COPY --from=foundry /usr/local/bin/cast /usr/local/bin/cast
+COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/anvil
+
+WORKDIR /app

--- a/.devcontainer/dev.env.example
+++ b/.devcontainer/dev.env.example
@@ -1,0 +1,3 @@
+# insert INFURA_API_KEY and copy to 'dev.env' file
+INFURA_API_KEY=
+FORK_URL=https://mainnet.infura.io/v3/${INFURA_API_KEY}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Universal Router Dev",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "devcontainer",
+	"workspaceFolder": "/app/${localWorkspaceFolderBasename}",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"GitHub.copilot-chat",
+				"GitHub.copilot-nightly",
+				"eamodio.gitlens",
+				"JuanBlanco.solidity",
+				"tintinweb.solidity-visual-auditor",
+				"tintinweb.vscode-ethover",
+				"github.vscode-github-actions"
+			]
+		}
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  devcontainer:
+    env_file: dev.env
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ../..:/app:cached
+    command: sleep infinity

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
+COMPOSE_PROJECT_NAME=universal-router
 INFURA_API_KEY=


### PR DESCRIPTION
@hensha256 As someone who routinely switches  between languages, toolchains and stacks, I lean heavily towards doing development in containerized environments, particularly VS Code devcontainers.

In this PR, I have added VS Code devcontainer support for universal router. I have created a multi-stage dockerfile that copies the foundry executables into a node18 image. The resulting image can be used to run both hardhat and foundry.

The base image is a custom foundry multi-arch image (restlessronin/foundry) that is based on debian (VS code doesn't work well with alpine images). I have submitted the dockerfile for this custom image  to the foundry project (https://github.com/foundry-rs/foundry/pull/4992), and I am hopeful that it will be incorporated into the official image.