### PR TITLE
feat: add a Gnosis Chain deployment config

### DIFF
--- a/script/deployParameters/DeployGnosis.s.sol
+++ b/script/deployParameters/DeployGnosis.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import {DeployUniversalRouter} from '../DeployUniversalRouter.s.sol';
+import {RouterParameters} from 'contracts/base/RouterImmutables.sol';
+
+contract DeployArbitrum is DeployUniversalRouter {
+    function setUp() public override {
+        params = RouterParameters({
+            permit2: UNSUPPORTED_PROTOCOL,
+            weth9: 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d,
+            steth: UNSUPPORTED_PROTOCOL,
+            wsteth: UNSUPPORTED_PROTOCOL,
+            seaportV1_5: UNSUPPORTED_PROTOCOL,
+            seaportV1_4: UNSUPPORTED_PROTOCOL,
+            openseaConduit: UNSUPPORTED_PROTOCOL,
+            nftxZap: UNSUPPORTED_PROTOCOL,
+            x2y2: UNSUPPORTED_PROTOCOL,
+            foundation: UNSUPPORTED_PROTOCOL,
+            sudoswap: UNSUPPORTED_PROTOCOL,
+            elementMarket: UNSUPPORTED_PROTOCOL,
+            nft20Zap: UNSUPPORTED_PROTOCOL,
+            cryptopunks: UNSUPPORTED_PROTOCOL,
+            looksRareV2: UNSUPPORTED_PROTOCOL,
+            routerRewardsDistributor: UNSUPPORTED_PROTOCOL,
+            looksRareRewardsDistributor: UNSUPPORTED_PROTOCOL,
+            looksRareToken: UNSUPPORTED_PROTOCOL,
+            v2Factory: UNSUPPORTED_PROTOCOL,
+            v3Factory: 0xe32F7dD7e3f098D518ff19A22d5f028e076489B1,
+            pairInitCodeHash: 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f,
+            poolInitCodeHash: 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54
+        });
+
+        unsupported = UNSUPPORTED_PROTOCOL;
+    }
+}


### PR DESCRIPTION
I'm not exactly sure what the two `InitCodeHash` variables are about. I see that `pairInitCodeHash` is not set for the testnets but that all mainnet ones are set to `0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f`, so I'm presuming that this is also the value we should use?