### PR TITLE
Oz L-09

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "solidity.compileUsingRemoteVersion": "v0.8.26+commit.8a97fa7a"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "solidity.compileUsingRemoteVersion": "v0.8.26+commit.8a97fa7a"
-}

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -267,8 +267,7 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, V4SwapRout
             if (command == Commands.EXECUTE_SUB_PLAN) {
                 bytes calldata _commands = inputs.toBytes(0);
                 bytes[] calldata _inputs = inputs.toBytesArray(1);
-                (success, output) =
-                    (address(this)).call(abi.encodeWithSelector(Dispatcher.execute.selector, _commands, _inputs));
+                (success, output) = (address(this)).call(abi.encodeCall(Dispatcher.execute, (_commands, _inputs)));
             } else {
                 // placeholder area for commands 0x23-0x3f
                 revert InvalidCommandType(command);


### PR DESCRIPTION
## Related Issue
OZ L-09
https://defender.openzeppelin.com/v2/#/audit/43d4e491-c5b4-42ba-b0fc-7f5adc46a6b6/issues/L-09

## Description of changes
Use `abi.encodeCall` instead of `abi.encodeWithSelector` since `abi.encodeWithSelector` is not type safe and `abi.encodeWithSignature` is not typo safe