### PR TITLE
Abdk cvf105

### DIFF
--- a/contracts/UniversalRouter.sol
+++ b/contracts/UniversalRouter.sol
@@ -44,7 +44,7 @@ contract UniversalRouter is IUniversalRouter, Dispatcher {
 
         // loop through all given commands, execute them and pass along outputs as defined
         for (uint256 commandIndex = 0; commandIndex < numCommands;) {
-            bytes1 command = commands[commandIndex];
+            uint8 command = uint8(commands[commandIndex]);
 
             bytes calldata input = inputs[commandIndex];
 
@@ -60,7 +60,7 @@ contract UniversalRouter is IUniversalRouter, Dispatcher {
         }
     }
 
-    function successRequired(bytes1 command) internal pure returns (bool) {
+    function successRequired(uint8 command) internal pure returns (bool) {
         return command & Commands.FLAG_ALLOW_REVERT == 0;
     }
 

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -32,8 +32,8 @@ abstract contract Dispatcher is Payments, V2SwapRouter, V3SwapRouter, V4SwapRout
     /// @dev 2 masks are used to enable use of a nested-if statement in execution for efficiency reasons
     /// @return success True on success of the command, false on failure
     /// @return output The outputs or error messages, if any, from the command
-    function dispatch(bytes1 commandType, bytes calldata inputs) internal returns (bool success, bytes memory output) {
-        uint256 command = uint8(commandType & Commands.COMMAND_TYPE_MASK);
+    function dispatch(uint8 commandType, bytes calldata inputs) internal returns (bool success, bytes memory output) {
+        uint8 command = commandType & Commands.COMMAND_TYPE_MASK;
 
         success = true;
 

--- a/contracts/libraries/Commands.sol
+++ b/contracts/libraries/Commands.sol
@@ -5,53 +5,53 @@ pragma solidity ^0.8.24;
 /// @notice Command Flags used to decode commands
 library Commands {
     // Masks to extract certain bits of commands
-    bytes1 internal constant FLAG_ALLOW_REVERT = 0x80;
-    bytes1 internal constant COMMAND_TYPE_MASK = 0x3f;
+    uint8 internal constant FLAG_ALLOW_REVERT = 0x80;
+    uint8 internal constant COMMAND_TYPE_MASK = 0x3f;
 
     // Command Types. Maximum supported command at this moment is 0x3f.
 
     // Command Types where value<0x08, executed in the first nested-if block
-    uint256 constant V3_SWAP_EXACT_IN = 0x00;
-    uint256 constant V3_SWAP_EXACT_OUT = 0x01;
-    uint256 constant PERMIT2_TRANSFER_FROM = 0x02;
-    uint256 constant PERMIT2_PERMIT_BATCH = 0x03;
-    uint256 constant SWEEP = 0x04;
-    uint256 constant TRANSFER = 0x05;
-    uint256 constant PAY_PORTION = 0x06;
+    uint8 constant V3_SWAP_EXACT_IN = 0x00;
+    uint8 constant V3_SWAP_EXACT_OUT = 0x01;
+    uint8 constant PERMIT2_TRANSFER_FROM = 0x02;
+    uint8 constant PERMIT2_PERMIT_BATCH = 0x03;
+    uint8 constant SWEEP = 0x04;
+    uint8 constant TRANSFER = 0x05;
+    uint8 constant PAY_PORTION = 0x06;
     // COMMAND_PLACEHOLDER = 0x07;
 
     // The commands are executed in nested if blocks to minimise gas consumption
     // The following constant defines one of the boundaries where the if blocks split commands
-    uint256 constant FIRST_IF_BOUNDARY = 0x08;
+    uint8 constant FIRST_IF_BOUNDARY = 0x08;
 
     // Command Types where 0x08<=value<=0x0f, executed in the second nested-if block
-    uint256 constant V2_SWAP_EXACT_IN = 0x08;
-    uint256 constant V2_SWAP_EXACT_OUT = 0x09;
-    uint256 constant PERMIT2_PERMIT = 0x0a;
-    uint256 constant WRAP_ETH = 0x0b;
-    uint256 constant UNWRAP_WETH = 0x0c;
-    uint256 constant PERMIT2_TRANSFER_FROM_BATCH = 0x0d;
-    uint256 constant BALANCE_CHECK_ERC20 = 0x0e;
+    uint8 constant V2_SWAP_EXACT_IN = 0x08;
+    uint8 constant V2_SWAP_EXACT_OUT = 0x09;
+    uint8 constant PERMIT2_PERMIT = 0x0a;
+    uint8 constant WRAP_ETH = 0x0b;
+    uint8 constant UNWRAP_WETH = 0x0c;
+    uint8 constant PERMIT2_TRANSFER_FROM_BATCH = 0x0d;
+    uint8 constant BALANCE_CHECK_ERC20 = 0x0e;
     // COMMAND_PLACEHOLDER = 0x0f;
 
     // The commands are executed in nested if blocks to minimise gas consumption
     // The following constant defines one of the boundaries where the if blocks split commands
-    uint256 constant SECOND_IF_BOUNDARY = 0x10;
+    uint8 constant SECOND_IF_BOUNDARY = 0x10;
 
-    uint256 constant V4_SWAP = 0x10;
-    uint256 constant V3_POSITION_MANAGER_PERMIT = 0x11;
-    uint256 constant V3_POSITION_MANAGER_CALL = 0x12;
-    uint256 constant V4_POSITION_CALL = 0x13;
-
-    // The commands are executed in nested if blocks to minimise gas consumption
-    // The following constant defines one of the boundaries where the if blocks split commands
-    uint256 constant THIRD_IF_BOUNDARY = 0x18;
+    uint8 constant V4_SWAP = 0x10;
+    uint8 constant V3_POSITION_MANAGER_PERMIT = 0x11;
+    uint8 constant V3_POSITION_MANAGER_CALL = 0x12;
+    uint8 constant V4_POSITION_CALL = 0x13;
 
     // The commands are executed in nested if blocks to minimise gas consumption
     // The following constant defines one of the boundaries where the if blocks split commands
-    uint256 constant FOURTH_IF_BOUNDARY = 0x20;
+    uint8 constant THIRD_IF_BOUNDARY = 0x18;
+
+    // The commands are executed in nested if blocks to minimise gas consumption
+    // The following constant defines one of the boundaries where the if blocks split commands
+    uint8 constant FOURTH_IF_BOUNDARY = 0x20;
 
     // Command Types where 0x20<=value
-    uint256 constant EXECUTE_SUB_PLAN = 0x21;
+    uint8 constant EXECUTE_SUB_PLAN = 0x21;
     // COMMAND_PLACEHOLDER for 0x23 to 0x3f (all unused)
 }

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalRouter.gas.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UniversalRouter Gas Tests gas: bytecode size 1`] = `18833`;
+exports[`UniversalRouter Gas Tests gas: bytecode size 1`] = `18802`;


### PR DESCRIPTION
## Related Issue
ABDK-CVF105:

## Description of changes
use uint8 instead of bytes1 to avoid shift operation to save gas

it actually doesn't save gas (i'm not sure why there would be a shift operation when converting from bytes1 to uint8?) but it does save some bytecode. thoughts?