### PR TITLE
fix(ci): Move to npm publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,9 +40,7 @@ jobs:
         run: yarn compile
 
       - name: Install npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.6.2
 
       - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn publish
+        run: npm publish

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "@uniswap/universal-router",
   "description": "Smart contracts for Universal Router",
   "license": "GPL-2.0-or-later",
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  },
   "version": "2.1.0",
   "keywords": [
     "uniswap",


### PR DESCRIPTION
- Pinned npm version
- Moved from yarn publish to npm publish to support trusted publishing
- Removing unused publish config