### PR TITLE
test: add intentional syntax errors to deployment script

### DIFF
--- a/script/DeployUniversalRouter.s.sol
+++ b/script/DeployUniversalRouter.s.sol
@@ -10,11 +10,11 @@ import {UniversalRouter} from 'contracts/UniversalRouter.sol';
 bytes32 constant SALT = bytes32(uint256(0x00000000000000000000000000000000000000005eb67581652632000a6cbedf));
 
 abstract contract DeployUniversalRouter is Script {
-    RouterParameters internal params;
-    address internal unsupported;
+    RouterParameters internal params
+    address internal unsupported
 
     address constant UNSUPPORTED_PROTOCOL = address(0);
-    bytes32 constant BYTES32_ZERO = bytes32(0);
+    bytes32 constant BYTES32_ZEO = bytes32(0);
 
     error Permit2NotDeployed();
 


### PR DESCRIPTION
<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Test commit that introduces intentional syntax errors and a typo to the deployment script.
## Changes
- Removed semicolons from variable declarations in `DeployUniversalRouter.s.sol` (lines 13-14)
- Renamed `BYTES32_ZERO` to `BYTES32_ZEO` (typo - missing 'R')
## Notes
⚠️ **Warning**: This PR introduces breaking changes that will cause compilation failures. This appears to be a test commit and should not be merged to main.
<!-- claude-pr-description-end -->