### PR TITLE
fix(ci): bump ai-toolkit reusable workflows past #453 RCE hardening

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ jobs:
   claude-review-auto:
     if: |
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.action != 'review_requested' &&
       !contains(github.head_ref, 'gh-readonly-queue/') &&
       !startsWith(github.head_ref, 'release/') &&
@@ -20,12 +21,12 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@9aa3cf98744a2b4e1aac51cd2d26144ea337ab3b
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       force_review: false
-      toolkit_ref: 9aa3cf98744a2b4e1aac51cd2d26144ea337ab3b
+      toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
       custom_prompt_path: '.claude/prompts/claude-pr-review.md'
 
       model: 'claude-opus-4-6'

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -29,13 +29,14 @@ jobs:
     # - Dependabot PRs (already have proper titles)
     # - Release PRs (have their own format)
     if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.head_ref, 'gh-readonly-queue/') &&
       !contains(github.head_ref, 'gtmq') &&
       !contains(github.head_ref, 'dependabot/') &&
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@9aa3cf98744a2b4e1aac51cd2d26144ea337ab3b
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Cantina bounty finding **#694** flagged that this repo's caller workflows pin a December 2025 SHA of `Uniswap/ai-toolkit/_claude-code-review.yml` that predates the fork-PR-RCE hardening in [`ai-toolkit#453`](https://github.com/Uniswap/ai-toolkit/commit/084ed0f93757da101364aecd5dd453cd3e888ff5) (merged 2026-04-30). SHA-pinned reusable workflows do not auto-pull upstream security fixes — the workflow body is frozen at the pinned SHA. Closes the chain on the receiving side with two independent defenses.

## What changed

**Bump the pinned SHA (`9aa3cf98...` → `96ef665b...`)** on both caller workflows so the reusable body now ships the four protections from #453: `BUN_CONFIG_FILE=/dev/null` at job level, post-checkout sweep of `bunfig.toml`/`.npmrc`/`.yarnrc`, `persist-credentials: false` on the PR checkout, and `bullfrog` switched from `audit` to `block` mode. The `toolkit_ref:` input value is bumped in lockstep with the `uses:` ref so the in-job download URL also advances.

**Add a caller-side fork-author guard** (`github.event.pull_request.head.repo.full_name == github.repository`) on both jobs' `if:` expressions. This stops fork PRs from reaching the reusable at all, independent of how stale or fresh the pinned SHA is. Mirrors the pattern already in `Uniswap/uniswap-ai/.github/workflows/claude-docs-check.yml`.

The combination is belt-and-braces: either change closes the original kill-chain on its own, but landing both is the recommended path per the finding.

## Test plan

- [x] No-op for fork PRs (the guard short-circuits before any reusable invocation).
- [x] Same-repo PRs continue to flow into the reusable; the only behavior change is that the reusable body is the post-#453 hardened version.
- [ ] First same-repo PR after merge will exercise both workflows end-to-end.

## Session context

### Investigation

The Cantina finding identified the December 2025 pin as vulnerable and named PR `#474` as a stale auto-bot bump attempt. PR #474 had already been closed on 2026-04-01 — *before* the hardening landed on 2026-04-30 — so its target SHA (`45880f79...`) is itself pre-hardening. Reopening #474 wouldn't have fixed this issue. Verified the cutoff by `git merge-base --is-ancestor 084ed0f <pinned>` against every ai-toolkit reusable SHA in use across the org; six unique SHAs in the wild are all pre-#453.

### Options evaluated

1. **Fork guard only.** Closes the kill-chain because fork PRs can never reach the reusable, but leaves the pinned reusable body itself vulnerable to any other bug class that might be exploitable from a same-repo collaborator PR.
2. **SHA bump only.** Picks up #453's protections, but offers no caller-side defense if a future hardening lands and the pin drifts again.
3. **Both (chosen).** Cantina's recommended remediation. Independent of pin freshness *and* current with upstream protections.

### Constraints discovered

- `pull_request_target` event semantics would have made the fork guard wrong (that event type is *designed* to receive secrets on fork PRs); both files here trigger on plain `pull_request`, so the guard is unambiguously safe.
- `toolkit_ref:` is a separate input that the reusable uses to download supporting scripts at runtime; bumping `uses:` without bumping `toolkit_ref:` would have left a runtime cross-version skew. Both updated.

### Org-wide footprint (separate PRs forthcoming)

Same vulnerability class affects 11 other Uniswap repos pinning various pre-#453 SHAs of ai-toolkit reusables: `protocol-fees`, `security`, `backend`, `universe`, `v4-hooks-public`, `v4-hooks-internal`, `hooks`, `initializer`, `sdks`, `ai-sandbox`, `uniswap-ai`. Each will get its own PR.

### Follow-up

Per finding's recommendation, rotate `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` on this repo as a precaution after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)