### PR TITLE
fix(deploy): exclude permissionsAdapterFactory from mapUnsupported

### DIFF
--- a/script/DeployUniversalRouter.s.sol
+++ b/script/DeployUniversalRouter.s.sol
@@ -41,7 +41,7 @@ abstract contract DeployUniversalRouter is Script {
             pairInitCodeHash: params.pairInitCodeHash,
             poolInitCodeHash: params.poolInitCodeHash,
             v4PoolManager: mapUnsupported(params.v4PoolManager),
-            permissionsAdapterFactory: mapUnsupported(params.permissionsAdapterFactory),
+            permissionsAdapterFactory: params.permissionsAdapterFactory, // skip mapUnsupported: address(0) signals permissioned-pools disabled
             v3NFTPositionManager: mapUnsupported(params.v3NFTPositionManager),
             v4PositionManager: mapUnsupported(params.v4PositionManager),
             spokePool: mapUnsupported(params.spokePool)


### PR DESCRIPTION
## Related Issue
- [ECO-351](https://linear.app/uniswap/issue/ECO-351)

## Description
- `PermissionedV4Router` treats `PERMISSIONS_ADAPTER_FACTORY == address(0)` as the disabled mode for permissioned pools. `DeployUniversalRouter.run` was rewriting that zero address to an `UnsupportedProtocol` dummy via `mapUnsupported`. After deployment, the router would see a non-zero factory address; any ERC20 `V4_SWAP` settle would call `verifiedPermissionsAdapterOf(...)` on the dummy contract, which reverts in its fallback, bricking all v4 swaps on chains where the factory isn't deployed yet.
- Skips `mapUnsupported` for `permissionsAdapterFactory` only; all other fields keep the existing behavior.