### PR TITLE
chore(deps): update ai-toolkit reusable workflow SHAs to c4820d6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@6d35d60ab7805aefae2837776d870787d93c8a18
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@6d35d60ab7805aefae2837776d870787d93c8a18
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@c4820d6e62a9488c831e722aac202733fafab5dd
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -36,7 +36,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -36,7 +36,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@6d35d60ab7805aefae2837776d870787d93c8a18
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@c4820d6e62a9488c831e722aac202733fafab5dd
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -36,7 +36,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@6d35d60ab7805aefae2837776d870787d93c8a18
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Automated update of `Uniswap/ai-toolkit` reusable workflow SHA references.

**Updated to:** `f43e9a271d5980407bd3a375b9ed0394f79e7f3d`

### Recent ai-toolkit changes

- chore(slack-oauth-backend): log OAuth request and Slack-granted scopes (#520)
- chore(sync): [skip ci] sync next with main
- fix(slack-oauth-backend): drop incoming-webhook bot scope (#518)
- feat(slack-oauth-backend): expand OAuth scope requests to match app manifest (#517)
- Merge pull request #519 from Uniswap/fix/claude-author-identity

### Files updated

- `.github/workflows/claude-code-review.yml`
- `.github/workflows/claude-pr-metadata-update.yml`


*Auto-created by ai-toolkit workflow sync task.*

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Automated bump of the SHA-pinned `Uniswap/ai-toolkit` reusable workflow references from `96ef665ba04221de07e94fcc3ea69fe32c7cf306` to `c4820d6e62a9488c831e722aac202733fafab5dd`.
## Changes
- `.github/workflows/claude-code-review.yml`: bump `uses:` pin for `_claude-code-review.yml`
- `.github/workflows/claude-pr-metadata-update.yml`: bump `uses:` pin for `_generate-pr-metadata.yml`
## Notes
- Pin-only change — no workflow triggers, inputs, or secrets were modified. The caller-side fork-author guards added in #479 are unchanged.
- Both files lost their trailing newline in this update; harmless for YAML parsing but worth restoring on the next touch.

</details>
<!-- claude-pr-description-end -->