### PR TITLE
chore(deps): maintain Claude Code Action workflows (cca=v1.0.185, ait=c4820d6)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,13 +21,13 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@27e7e2de432ac025b23051c5ffab8d88a342b1f9
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@9b405c71e42d0cec4026f2c158edf99716600baa
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       force_review: false
       toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
-      model: 'claude-opus-4-8'
+      model: 'claude-opus-5'
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,15 +21,13 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@27e7e2de432ac025b23051c5ffab8d88a342b1f9
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       force_review: false
       toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
-      custom_prompt_path: '.claude/prompts/claude-pr-review.md'
-
-      model: 'claude-opus-4-6'
+      model: 'claude-opus-4-8'
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,8 @@ jobs:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
       force_review: false
-      toolkit_ref: 96ef665ba04221de07e94fcc3ea69fe32c7cf306
+      toolkit_ref: c4820d6e62a9488c831e722aac202733fafab5dd
+      custom_prompt_path: '.claude/prompts/claude-pr-review.md'
       model: 'claude-opus-5'
 
       # Standard timeout for most PRs

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
         github.event.action == 'ready_for_review'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@9b405c71e42d0cec4026f2c158edf99716600baa
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@c4820d6e62a9488c831e722aac202733fafab5dd
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,6 @@ jobs:
       base_ref: ${{ github.base_ref }}
       force_review: false
       toolkit_ref: c4820d6e62a9488c831e722aac202733fafab5dd
-      custom_prompt_path: '.claude/prompts/claude-pr-review.md'
       model: 'claude-opus-5'
 
       # Standard timeout for most PRs

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -36,7 +36,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@27e7e2de432ac025b23051c5ffab8d88a342b1f9
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -36,7 +36,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@9b405c71e42d0cec4026f2c158edf99716600baa
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@c4820d6e62a9488c831e722aac202733fafab5dd
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-metadata-update.yml
+++ b/.github/workflows/claude-pr-metadata-update.yml
@@ -36,7 +36,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@27e7e2de432ac025b23051c5ffab8d88a342b1f9
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@9b405c71e42d0cec4026f2c158edf99716600baa
     with:
       generation_mode: "description,deferred-title"
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:

- **claude-code-action:** `v1.0.133` (`787c5a0`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.133
- **ai-toolkit reusable workflows:** `27e7e2d` (Uniswap/ai-toolkit `next` HEAD)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-4-8`
  - `sonnet` → `claude-sonnet-4-6`

### Per-file changes

#### `.github/workflows/claude-code-review.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml`: `96ef665` → `27e7e2d`
- **Breaking-change auto-fix:** removed deprecated input `custom_prompt_path` (no longer in Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml at the new SHA)
- Model bump: `claude-opus-4-6` → `claude-opus-4-8`

#### `.github/workflows/claude-pr-metadata-update.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml`: `96ef665` → `27e7e2d`



_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Maintenance pass on the two Claude Code Action caller workflows. Bumps the pinned `Uniswap/ai-toolkit` reusable-workflow SHA on both callers, bumps the review model, and drops an input that no longer exists on the reusable at the new SHA.
- **ai-toolkit reusable workflows:** `96ef665` → `c4820d6`
- **Review model:** `claude-opus-4-6` → `claude-opus-5`
- **Removed input:** `custom_prompt_path` (breaking-change migration, see Notes)
## Changes
### `.github/workflows/claude-code-review.yml`
- SHA bump `uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml`: `96ef665` → `c4820d6`
- `toolkit_ref` bumped in lockstep with `uses:`: `96ef665` → `c4820d6`
- Model bump: `claude-opus-4-6` → `claude-opus-5`
- Removed `custom_prompt_path: '.claude/prompts/claude-pr-review.md'`
- Dropped a stray blank line before `model:`
### `.github/workflows/claude-pr-metadata-update.yml`
- SHA bump `uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml`: `96ef665` → `c4820d6`
## Notes
- **`custom_prompt_path` removal is required, not a regression.** Verified against `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@c4820d6`: the input no longer exists. It has been superseded by a set of granular `prompt_override_*` inputs (`prompt_override_review_priorities`, `prompt_override_communication_style`, `prompt_override_avoid_patterns`, and others). Passing the removed input would fail workflow validation.
- **Reviewer action item:** `.claude/prompts/claude-pr-review.md` is still present in the repo but is now orphaned — nothing references it. Review customizations it encoded are no longer applied. A follow-up should either port its contents into the appropriate `prompt_override_*` inputs or delete the file. Note that an earlier commit on this branch (`3da5904`) restored this input; that restore is reverted here because the input is genuinely gone upstream.
- **`toolkit_ref` must move with `uses:`.** The reusable uses `toolkit_ref` to fetch supporting scripts at runtime, so leaving it behind would create a cross-version skew between the workflow body and its scripts — matching what #479 did deliberately.
- **No `anthropics/claude-code-action` pin changes in this diff.** This repo does not pin `claude-code-action` directly; it is pinned inside the reusable, which sits at `787c5a0` (v1.0.133) at the new SHA. The `cca=` token in the PR title is maintenance-job bookkeeping and does not correspond to anything in these two files.
- The prior AI-generated description block in this PR body stated that `custom_prompt_path` was retained. That is no longer true of the current diff.
_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._

</details>
<!-- claude-pr-description-end -->