### PR TITLE
fix: Tempo deploy script compilation and stale foundry.lock

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,6 +1,6 @@
 {
   "lib/forge-std": {
-    "rev": "73d44ec7d124e3831bc5f832267889ffb6f9bc3f"
+    "rev": "3b20d60d14b343ee4f908cb8079495c07f5e8981"
   },
   "lib/permit2": {
     "rev": "cc56ad0f3439c502c246fc5cfcc3db92bb8b7219"
@@ -14,7 +14,7 @@
   "lib/v4-periphery": {
     "branch": {
       "name": "main",
-      "rev": "9dafaaecc1e2e1e824eda9d941085f96517d827b"
+      "rev": "363226d9e1e2180b67bf6857023dbaad751010c5"
     }
   }
 }

--- a/script/deployParameters/DeployTempo.s.sol
+++ b/script/deployParameters/DeployTempo.s.sol
@@ -14,6 +14,7 @@ contract DeployTempo is DeployUniversalRouter {
             pairInitCodeHash: 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f,
             poolInitCodeHash: 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54,
             v4PoolManager: 0x33620f62C5b9B2086dD6b62F4A297A9f30347029,
+            permissionsAdapterFactory: address(0), // ToDo: Add permissions adapter factory
             v3NFTPositionManager: 0xb71C33f096CEabDC0229110e0d76a6382d01C633,
             v4PositionManager: 0x3Fc79444F8EACc1894775493Ff3Fa41f1e35Ce11,
             spokePool: UNSUPPORTED_PROTOCOL


### PR DESCRIPTION
A clean checkout of main currently fails `forge build`. DeployTempo.s.sol was added in #478 but written against the RouterParameters struct from before #476, which added the permissionsAdapterFactory field, so the struct constructor in the Tempo deployer is one argument short. I added the missing field as address(0), the same way the fix that's sitting on feat/v4-swap-within-unlock-hardened does it.

While debugging this I also noticed foundry.lock was left stale by #476: it still pins forge-std at v1.5.5 (73d44ec) and v4-periphery at 9dafaae, while the git submodule pointers were bumped to v1.9.6 (3b20d60) and the Permissioned Pools commit (363226d). That makes forge print revision mismatch warnings on every build. I synced the two rev entries to the committed submodule revisions; 363226d is on v4-periphery main, so the branch pairing in the lock stays valid.

With both changes, forge build on a fresh checkout compiles with no errors and no dependency warnings.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Fixes two issues that cause `forge build` to fail or emit warnings on a fresh checkout of `main`.
## Changes
- **DeployTempo.s.sol**: Add missing `permissionsAdapterFactory: address(0)` field to the `RouterParameters` struct constructor, aligning it with the field added in #476
- **foundry.lock**: Update `forge-std` rev (`73d44ec` → `3b20d60`) and `v4-periphery` rev (`9dafaae` → `363226d`) to match the committed submodule pointers, eliminating revision-mismatch warnings
## Notes
- `permissionsAdapterFactory` is set to `address(0)`, which disables permissioned pools — consistent with the pattern used in other deploy scripts
- Both stale entries were left behind by #476 when it bumped the git submodules without updating the lock file
- With both fixes applied, `forge build` compiles cleanly on a fresh clone with no errors or dependency warnings

</details>
<!-- claude-pr-description-end -->