### PR TITLE
feat: add BalanceSwapProxy for full-balance swaps with pre-signed routes

### DIFF
--- a/contracts/BalanceSwapProxy.sol
+++ b/contracts/BalanceSwapProxy.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import {ERC20} from 'solmate/src/tokens/ERC20.sol';
+import {SafeTransferLib} from 'solmate/src/utils/SafeTransferLib.sol';
+import {IPermit2} from 'permit2/src/interfaces/IPermit2.sol';
+import {ISignatureTransfer} from 'permit2/src/interfaces/ISignatureTransfer.sol';
+import {SafeCast160} from 'permit2/src/libraries/SafeCast160.sol';
+import {Constants} from './libraries/Constants.sol';
+import {IUniversalRouter} from './interfaces/IUniversalRouter.sol';
+import {IBalanceSwapProxy} from './interfaces/IBalanceSwapProxy.sol';
+
+/// @title BalanceSwapProxy
+/// @notice Swaps a user's entire token balance through the Universal Router — relayed via a
+///         pre-signed, route-bound Permit2 witness, or directly by the owner via a standing
+///         approval (plain ERC20 or Permit2 AllowanceTransfer).
+/// @dev Stateless and non-custodial: tokens are pulled straight into the router (never held
+///      here) and the route runs against the router's own balance.
+///      Route requirements (mirroring SwapProxy):
+///      - All swap commands MUST use payerIsUser=false.
+///      - All recipients MUST be explicit addresses, never the MSG_SENDER sentinel, which
+///        resolves to this proxy inside router execution.
+///      - Routes SHOULD consume the full pulled amount (CONTRACT_BALANCE / OPEN_DELTA inputs)
+///        and SWEEP any residue: anything left in the router is stealable by the next caller.
+///      - Fee-on-transfer and rebasing input tokens are unsupported (floor is computed on the
+///        pulled amount and will bias toward revert).
+///      - Native input is unsupported; native output is expressed as tokenOut = address(0)
+///        with a route ending in UNWRAP_WETH(recipient, 0).
+contract BalanceSwapProxy is IBalanceSwapProxy {
+    using SafeTransferLib for ERC20;
+    using SafeCast160 for uint256;
+
+    /// @notice EIP-712 typehash of the witness struct signed alongside the Permit2 transfer.
+    /// @dev routeHash = keccak256(abi.encode(commands, inputs)), derived in-contract.
+    bytes32 public constant SWAP_INTENT_TYPEHASH = keccak256(
+        'SwapIntent(bytes32 routeHash,address router,address tokenOut,address recipient,uint256 minPriceX36,uint256 minAmount)'
+    );
+
+    /// @notice Witness type suffix completing Permit2's PermitWitnessTransferFrom typehash stub
+    string public constant WITNESS_TYPE_STRING =
+        'SwapIntent witness)SwapIntent(bytes32 routeHash,address router,address tokenOut,address recipient,uint256 minPriceX36,uint256 minAmount)TokenPermissions(address token,uint256 amount)';
+
+    IPermit2 public immutable PERMIT2;
+
+    constructor(IPermit2 permit2) {
+        PERMIT2 = permit2;
+    }
+
+    /// @inheritdoc IBalanceSwapProxy
+    function executeWithSig(
+        ISignatureTransfer.PermitTransferFrom calldata permit,
+        bytes calldata permitSig,
+        address owner,
+        SwapIntent calldata intent,
+        bytes calldata commands,
+        bytes[] calldata inputs
+    ) external {
+        uint256 amount = _resolveAmount(permit.permitted.token, intent, owner, permit.permitted.amount);
+        uint256 balBefore = _outputBalance(intent.tokenOut, intent.recipient);
+
+        // Pull straight into the router. Permit2 verifies the witness (including the derived
+        // route hash), consumes the unordered nonce, and enforces permit.deadline.
+        PERMIT2.permitWitnessTransferFrom(
+            permit,
+            ISignatureTransfer.SignatureTransferDetails({to: intent.router, requestedAmount: amount}),
+            owner,
+            _hashIntent(intent, keccak256(abi.encode(commands, inputs))),
+            WITNESS_TYPE_STRING,
+            permitSig
+        );
+
+        IUniversalRouter(intent.router).execute(commands, inputs, permit.deadline);
+
+        _checkOutput(intent, amount, balBefore);
+    }
+
+    /// @inheritdoc IBalanceSwapProxy
+    function execute(
+        address tokenIn,
+        SwapIntent calldata intent,
+        bytes calldata commands,
+        bytes[] calldata inputs,
+        uint256 deadline
+    ) external {
+        uint256 amount = _resolveAmount(tokenIn, intent, msg.sender, type(uint256).max);
+        uint256 balBefore = _outputBalance(intent.tokenOut, intent.recipient);
+
+        ERC20(tokenIn).safeTransferFrom(msg.sender, intent.router, amount);
+        IUniversalRouter(intent.router).execute(commands, inputs, deadline);
+
+        _checkOutput(intent, amount, balBefore);
+    }
+
+    /// @inheritdoc IBalanceSwapProxy
+    function executeWithPermit2Allowance(
+        address tokenIn,
+        SwapIntent calldata intent,
+        bytes calldata commands,
+        bytes[] calldata inputs,
+        uint256 deadline
+    ) external {
+        uint256 amount = _resolveAmount(tokenIn, intent, msg.sender, type(uint256).max);
+        uint256 balBefore = _outputBalance(intent.tokenOut, intent.recipient);
+
+        PERMIT2.transferFrom(msg.sender, intent.router, amount.toUint160(), tokenIn);
+        IUniversalRouter(intent.router).execute(commands, inputs, deadline);
+
+        _checkOutput(intent, amount, balBefore);
+    }
+
+    /// @dev Resolves the amount to swap (full balance, capped) and enforces shared preconditions.
+    function _resolveAmount(address tokenIn, SwapIntent calldata intent, address owner, uint256 cap)
+        private
+        view
+        returns (uint256 amount)
+    {
+        if (tokenIn == intent.tokenOut) revert SameToken();
+        amount = ERC20(tokenIn).balanceOf(owner);
+        if (amount > cap) amount = cap;
+        if (amount == 0 || amount < intent.minAmount) revert InsufficientBalance(amount, intent.minAmount);
+    }
+
+    /// @dev Enforces the rate floor on the recipient's output balance delta. minPriceX36 == 0 disables.
+    function _checkOutput(SwapIntent calldata intent, uint256 amount, uint256 balBefore) private view {
+        if (intent.minPriceX36 == 0) return;
+        uint256 delta = _outputBalance(intent.tokenOut, intent.recipient) - balBefore;
+        // checked math: overflow (amount > ~1.1e41 base units) reverts, a safe failure mode
+        uint256 floor = amount * intent.minPriceX36 / Constants.PRICE_PRECISION;
+        if (delta < floor) revert InsufficientOutput(delta, floor);
+    }
+
+    /// @dev tokenOut == address(0) means native ETH
+    function _outputBalance(address tokenOut, address recipient) private view returns (uint256) {
+        return tokenOut == address(0) ? recipient.balance : ERC20(tokenOut).balanceOf(recipient);
+    }
+
+    /// @dev EIP-712 hash of the SwapIntent witness with the derived route hash folded in
+    function _hashIntent(SwapIntent calldata intent, bytes32 routeHash) private pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                SWAP_INTENT_TYPEHASH,
+                routeHash,
+                intent.router,
+                intent.tokenOut,
+                intent.recipient,
+                intent.minPriceX36,
+                intent.minAmount
+            )
+        );
+    }
+}

--- a/contracts/interfaces/CLAUDE.md
+++ b/contracts/interfaces/CLAUDE.md
@@ -7,6 +7,8 @@ This directory contains Solidity interfaces for the Universal Router and externa
 ## Key Files
 
 - `IUniversalRouter.sol` - Main router interface with execute() methods and signature verification
+- `ISwapProxy.sol` - Proxy enabling 2-tx swap flow (ERC20 approve + swap) without Permit2 signatures
+- `IBalanceSwapProxy.sol` - Proxy for full-balance swaps: pre-signed route-bound Permit2 witness (relayed) or direct standing-approval modes
 - `external/IV3SpokePool.sol` - Across Protocol V3 bridge integration interface
 
 ## Purpose

--- a/contracts/interfaces/IBalanceSwapProxy.sol
+++ b/contracts/interfaces/IBalanceSwapProxy.sol
@@ -53,6 +53,11 @@ interface IBalanceSwapProxy {
 
     /// @notice Direct mode: pulls msg.sender's full tokenIn balance via a plain ERC20 allowance
     ///         granted to this contract, then executes and enforces the caller-supplied terms.
+    /// @param tokenIn The token pulled from msg.sender via ERC20 allowance
+    /// @param intent The swap terms, supplied directly by the caller
+    /// @param commands The Universal Router commands to execute
+    /// @param inputs The Universal Router inputs for each command
+    /// @param deadline The deadline by which the router execution must occur
     function execute(
         address tokenIn,
         SwapIntent calldata intent,
@@ -63,6 +68,11 @@ interface IBalanceSwapProxy {
 
     /// @notice Direct mode: same as execute(), but pulls via the caller's standing Permit2
     ///         AllowanceTransfer approval (this contract as spender).
+    /// @param tokenIn The token pulled from msg.sender via the caller's Permit2 allowance
+    /// @param intent The swap terms, supplied directly by the caller
+    /// @param commands The Universal Router commands to execute
+    /// @param inputs The Universal Router inputs for each command
+    /// @param deadline The deadline by which the router execution must occur
     function executeWithPermit2Allowance(
         address tokenIn,
         SwapIntent calldata intent,

--- a/contracts/interfaces/IBalanceSwapProxy.sol
+++ b/contracts/interfaces/IBalanceSwapProxy.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import {ISignatureTransfer} from 'permit2/src/interfaces/ISignatureTransfer.sol';
+
+/// @title IBalanceSwapProxy
+/// @notice Full-balance swaps through the Universal Router, with an optional pre-signed
+///         (Permit2 witness) relayed mode. The proxy is stateless and non-custodial: tokens
+///         are pulled straight into the router and swapped with payerIsUser=false.
+interface IBalanceSwapProxy {
+    /// @notice The swap terms. In the signed mode these are witness-bound (signed alongside a
+    ///         route hash the proxy derives from commands/inputs); in the direct modes they are
+    ///         supplied by the owner-caller. Every field is honored in every mode.
+    struct SwapIntent {
+        /// @dev The Universal Router this intent executes against
+        address router;
+        /// @dev Output token; address(0) = native ETH (route must end with UNWRAP_WETH to recipient)
+        address tokenOut;
+        /// @dev Where output must land (balance-delta-checked); never the MSG_SENDER sentinel
+        address recipient;
+        /// @dev Minimum output-per-input rate in base units, 1e36 fixed point; 0 disables the check
+        uint256 minPriceX36;
+        /// @dev Execute only if the resolved input amount is at least this (anti-dust-grief)
+        uint256 minAmount;
+    }
+
+    /// @notice Thrown when tokenIn == intent.tokenOut
+    error SameToken();
+    /// @notice Thrown when the resolved amount is zero or below intent.minAmount
+    error InsufficientBalance(uint256 amount, uint256 minAmount);
+    /// @notice Thrown when the recipient's output delta is below amount * minPriceX36 / 1e36
+    error InsufficientOutput(uint256 delta, uint256 floor);
+
+    /// @notice Relayed mode: pulls min(balanceOf(owner), permit cap) into the router via
+    ///         permitWitnessTransferFrom, executes the signed route, enforces the signed floor.
+    /// @dev The witness hash is computed from (keccak256(abi.encode(commands, inputs)), intent),
+    ///      so tampered routes fail Permit2 signature verification. permit.deadline doubles as
+    ///      the router execution deadline. Callable by anyone; the caller only pays gas.
+    /// @param permit permitted = {tokenIn, cap}; single-use unordered nonce; deadline = intent TTL
+    /// @param permitSig The owner's signature over the permit + SwapIntent witness
+    /// @param owner The permit signer; tokens are pulled from here
+    /// @param intent The swap terms bound into the witness
+    /// @param commands The Universal Router commands (route-hash-bound into the witness)
+    /// @param inputs The Universal Router inputs (route-hash-bound into the witness)
+    function executeWithSig(
+        ISignatureTransfer.PermitTransferFrom calldata permit,
+        bytes calldata permitSig,
+        address owner,
+        SwapIntent calldata intent,
+        bytes calldata commands,
+        bytes[] calldata inputs
+    ) external;
+
+    /// @notice Direct mode: pulls msg.sender's full tokenIn balance via a plain ERC20 allowance
+    ///         granted to this contract, then executes and enforces the caller-supplied terms.
+    function execute(
+        address tokenIn,
+        SwapIntent calldata intent,
+        bytes calldata commands,
+        bytes[] calldata inputs,
+        uint256 deadline
+    ) external;
+
+    /// @notice Direct mode: same as execute(), but pulls via the caller's standing Permit2
+    ///         AllowanceTransfer approval (this contract as spender).
+    function executeWithPermit2Allowance(
+        address tokenIn,
+        SwapIntent calldata intent,
+        bytes calldata commands,
+        bytes[] calldata inputs,
+        uint256 deadline
+    ) external;
+}

--- a/script/DeployBalanceSwapProxy.s.sol
+++ b/script/DeployBalanceSwapProxy.s.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import 'forge-std/console2.sol';
+import 'forge-std/Script.sol';
+import {IPermit2} from 'permit2/src/interfaces/IPermit2.sol';
+import {BalanceSwapProxy} from 'contracts/BalanceSwapProxy.sol';
+
+contract DeployBalanceSwapProxy is Script {
+    // canonical Permit2, same address on all chains
+    IPermit2 constant PERMIT2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
+
+    function run() external returns (BalanceSwapProxy balanceSwapProxy) {
+        vm.startBroadcast();
+        balanceSwapProxy = new BalanceSwapProxy(PERMIT2);
+        console2.log('BalanceSwapProxy Deployed:', address(balanceSwapProxy));
+        vm.stopBroadcast();
+    }
+}

--- a/script/deployParameters/DeployTempo.s.sol
+++ b/script/deployParameters/DeployTempo.s.sol
@@ -14,6 +14,7 @@ contract DeployTempo is DeployUniversalRouter {
             pairInitCodeHash: 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f,
             poolInitCodeHash: 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54,
             v4PoolManager: 0x33620f62C5b9B2086dD6b62F4A297A9f30347029,
+            permissionsAdapterFactory: address(0), // ToDo: Add permissions adapter factory
             v3NFTPositionManager: 0xb71C33f096CEabDC0229110e0d76a6382d01C633,
             v4PositionManager: 0x3Fc79444F8EACc1894775493Ff3Fa41f1e35Ce11,
             spokePool: UNSUPPORTED_PROTOCOL

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -252,4 +252,111 @@ contract BalanceSwapProxyTest is Test {
         );
         vm.stopPrank();
     }
+
+    // ---------- Mode 1: signed & relayed ----------
+
+    // Deliberately constructed independently of the contract's constants: if the contract's
+    // typestring drifts from this canonical encoding, these tests must fail.
+    bytes32 constant TEST_TOKEN_PERMISSIONS_TYPEHASH = keccak256('TokenPermissions(address token,uint256 amount)');
+    bytes32 constant TEST_SWAP_INTENT_TYPEHASH = keccak256(
+        'SwapIntent(bytes32 routeHash,address router,address tokenOut,address recipient,uint256 minPriceX36,uint256 minAmount)'
+    );
+    bytes32 constant TEST_PERMIT_WITNESS_TYPEHASH = keccak256(
+        'PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,SwapIntent witness)SwapIntent(bytes32 routeHash,address router,address tokenOut,address recipient,uint256 minPriceX36,uint256 minAmount)TokenPermissions(address token,uint256 amount)'
+    );
+
+    function _permit(address token, uint256 cap, uint256 nonce, uint256 deadline)
+        internal
+        pure
+        returns (ISignatureTransfer.PermitTransferFrom memory)
+    {
+        return ISignatureTransfer.PermitTransferFrom({
+            permitted: ISignatureTransfer.TokenPermissions({token: token, amount: cap}),
+            nonce: nonce,
+            deadline: deadline
+        });
+    }
+
+    function _signIntent(
+        ISignatureTransfer.PermitTransferFrom memory permit,
+        IBalanceSwapProxy.SwapIntent memory intent,
+        bytes memory commands,
+        bytes[] memory inputs,
+        uint256 privateKey
+    ) internal view returns (bytes memory sig) {
+        bytes32 witness = keccak256(
+            abi.encode(
+                TEST_SWAP_INTENT_TYPEHASH,
+                keccak256(abi.encode(commands, inputs)),
+                intent.router,
+                intent.tokenOut,
+                intent.recipient,
+                intent.minPriceX36,
+                intent.minAmount
+            )
+        );
+        bytes32 tokenPermissions = keccak256(abi.encode(TEST_TOKEN_PERMISSIONS_TYPEHASH, permit.permitted));
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                '\x19\x01',
+                PERMIT2.DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        TEST_PERMIT_WITNESS_TYPEHASH,
+                        tokenPermissions,
+                        address(proxy), // spender is bound to the proxy
+                        permit.nonce,
+                        permit.deadline,
+                        witness
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        sig = abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Owner signs at "bridge time" with a loose cap; balance is lower than the cap at fill.
+    function testSignedExecutePullsBalanceBelowCap() public {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT); // "bridge delivered" AMOUNT
+        tokenA.approve(address(PERMIT2), type(uint256).max); // one-time ERC20 -> Permit2 approval
+        vm.stopPrank();
+
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        IBalanceSwapProxy.SwapIntent memory intent = _intent(address(tokenB), RECIPIENT, 0.9e36, 0);
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            _permit(address(tokenA), type(uint256).max, 1, block.timestamp + 1000);
+        bytes memory sig = _signIntent(permit, intent, commands, inputs, OWNER_KEY);
+        uint256 expectedOut = _expectedOut(AMOUNT, pairAB, address(tokenA));
+
+        // relayed by an arbitrary third party
+        vm.prank(address(0xF177E4));
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+
+        assertEq(tokenA.balanceOf(OWNER), 0, 'full balance pulled');
+        assertEq(tokenB.balanceOf(RECIPIENT), expectedOut, 'output at signed recipient');
+        assertEq(tokenA.balanceOf(address(router)), 0, 'no residue');
+        assertEq(tokenA.balanceOf(address(proxy)), 0, 'proxy never custodies');
+    }
+
+    /// @dev Balance above the signed cap: pull is capped, excess stays with the owner.
+    function testSignedExecutePullsCapBelowBalance() public {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - 2 ether); // owner holds 2 ether
+        tokenA.approve(address(PERMIT2), type(uint256).max);
+        vm.stopPrank();
+
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        IBalanceSwapProxy.SwapIntent memory intent = _intent(address(tokenB), RECIPIENT, 0.9e36, 0);
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            _permit(address(tokenA), AMOUNT, 2, block.timestamp + 1000); // cap = 1 ether
+        bytes memory sig = _signIntent(permit, intent, commands, inputs, OWNER_KEY);
+
+        vm.prank(address(0xF177E4));
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+
+        assertEq(tokenA.balanceOf(OWNER), 1 ether, 'excess above cap untouched');
+        assertGt(tokenB.balanceOf(RECIPIENT), 0);
+    }
 }

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -9,12 +9,15 @@ import {IUniswapV2Factory} from '@uniswap/v2-core/contracts/interfaces/IUniswapV
 import {IUniswapV2Pair} from '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';
 import {ActionConstants} from '@uniswap/v4-periphery/src/libraries/ActionConstants.sol';
 import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {IUniversalRouter} from '../../contracts/interfaces/IUniversalRouter.sol';
 import {BalanceSwapProxy} from '../../contracts/BalanceSwapProxy.sol';
 import {IBalanceSwapProxy} from '../../contracts/interfaces/IBalanceSwapProxy.sol';
 import {Commands} from '../../contracts/libraries/Commands.sol';
 import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
 import {MockERC20} from './mock/MockERC20.sol';
 import {MockERC20Decimals} from './mock/MockERC20Decimals.sol';
+import {ReenteringERC20} from './mock/ReenteringERC20.sol';
+import {SwapProxy} from '../../contracts/SwapProxy.sol';
 import {SignatureVerification} from 'permit2/src/libraries/SignatureVerification.sol';
 
 // NOTE: permit2/src/PermitErrors.sol is pinned to an exact `pragma solidity 0.8.17;`, which is
@@ -667,5 +670,135 @@ contract BalanceSwapProxyTest is Test {
         assertGt(RECIPIENT.balance - ethBefore, 0.9 ether, 'recipient received native ETH above floor');
         assertEq(WETH9.balanceOf(address(router)), 0, 'no WETH residue');
         assertEq(address(router).balance, 0, 'no ETH residue');
+    }
+
+    // ---------- reentry statelessness ----------
+
+    /// @dev A token hook reenters the proxy mid-execution through a SECOND router (the UR's own
+    ///      lock forbids same-router reentry). Both executions complete independently; nothing
+    ///      is stranded. Proves the proxy carries no cross-call state.
+    function testReentryThroughSecondRouterIsIndependent() public {
+        // second router, same params as setUp
+        RouterParameters memory params = RouterParameters({
+            permit2: address(PERMIT2),
+            weth9: address(WETH9),
+            v2Factory: address(FACTORY),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            permissionsAdapterFactory: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0),
+            spokePool: address(0)
+        });
+        UniversalRouter router2 = new UniversalRouter(params);
+
+        // outer swap: tokenA -> EVIL (pair funded below)
+        ReenteringERC20 evil = new ReenteringERC20();
+        address pairAE = FACTORY.createPair(address(tokenA), address(evil));
+        tokenA.mint(pairAE, 100 ether);
+        evil.mint(pairAE, 100 ether);
+        IUniswapV2Pair(pairAE).sync();
+
+        // inner swap: EVIL contract itself swaps its tokenB through router2
+        address RECIPIENT2 = address(0x2222);
+        tokenB.mint(address(evil), AMOUNT);
+        vm.prank(address(evil));
+        tokenB.approve(address(proxy), type(uint256).max);
+        (bytes memory innerCommands, bytes[] memory innerInputs) =
+            _v2Route(address(tokenB), address(tokenA), RECIPIENT2);
+        IBalanceSwapProxy.SwapIntent memory innerIntent = IBalanceSwapProxy.SwapIntent({
+            router: address(router2),
+            tokenOut: address(tokenA),
+            recipient: RECIPIENT2,
+            minPriceX36: 0,
+            minAmount: 0
+        });
+        evil.arm(
+            address(proxy),
+            abi.encodeCall(
+                IBalanceSwapProxy.execute,
+                (address(tokenB), innerIntent, innerCommands, innerInputs, block.timestamp + 1000)
+            )
+        );
+
+        // outer execution (direct mode): EVIL's transfer to RECIPIENT triggers the inner call
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(evil), RECIPIENT);
+        proxy.execute(
+            address(tokenA),
+            IBalanceSwapProxy.SwapIntent({
+                router: address(router),
+                tokenOut: address(evil),
+                recipient: RECIPIENT,
+                minPriceX36: 0.9e36,
+                minAmount: 0
+            }),
+            commands,
+            inputs,
+            block.timestamp + 1000
+        );
+        vm.stopPrank();
+
+        // both executions landed; nothing stranded anywhere
+        assertGt(evil.balanceOf(RECIPIENT), 0, 'outer output delivered');
+        assertGt(tokenA.balanceOf(RECIPIENT2), 0, 'inner output delivered');
+        assertEq(tokenA.balanceOf(address(proxy)), 0);
+        assertEq(tokenB.balanceOf(address(proxy)), 0);
+        assertEq(tokenA.balanceOf(address(router)), 0);
+        assertEq(tokenB.balanceOf(address(router2)), 0);
+    }
+
+    // ---------- gas ----------
+
+    function testGasComparisonVsSwapProxyAndDirect() public {
+        SwapProxy swapProxy = new SwapProxy();
+        address user = address(0x6A5);
+        vm.startPrank(user);
+        tokenA.mint(user, 3 * AMOUNT);
+        tokenA.approve(address(proxy), type(uint256).max);
+        tokenA.approve(address(swapProxy), type(uint256).max);
+        tokenA.approve(address(PERMIT2), type(uint256).max);
+        PERMIT2.approve(address(tokenA), address(router), type(uint160).max, type(uint48).max);
+
+        address[] memory path = new address[](2);
+        path[0] = address(tokenA);
+        path[1] = address(tokenB);
+
+        // 1. BalanceSwapProxy direct mode (CONTRACT_BALANCE route) — must leave exactly AMOUNT
+        tokenA.transfer(address(0xDEAD), 2 * AMOUNT);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), user);
+        uint256 gasBefore = gasleft();
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), user, 0, 0), commands, inputs, block.timestamp + 1000
+        );
+        uint256 gasBalanceProxy = gasBefore - gasleft();
+
+        // 2. SwapProxy (exact amount)
+        tokenA.mint(user, AMOUNT);
+        bytes[] memory exactInputs = new bytes[](1);
+        exactInputs[0] = abi.encode(user, AMOUNT, 0, path, false, new uint256[](0));
+        gasBefore = gasleft();
+        swapProxy.execute(
+            IUniversalRouter(address(router)), address(tokenA), AMOUNT, commands, exactInputs,
+            block.timestamp + 1000
+        );
+        uint256 gasSwapProxy = gasBefore - gasleft();
+
+        // 3. UR direct via Permit2 allowance (payerIsUser = true)
+        tokenA.mint(user, AMOUNT);
+        bytes[] memory directInputs = new bytes[](1);
+        directInputs[0] = abi.encode(user, AMOUNT, 0, path, true, new uint256[](0));
+        gasBefore = gasleft();
+        router.execute(commands, directInputs, block.timestamp + 1000);
+        uint256 gasDirect = gasBefore - gasleft();
+        vm.stopPrank();
+
+        emit log_named_uint('Gas via BalanceSwapProxy (direct mode)', gasBalanceProxy);
+        emit log_named_uint('Gas via SwapProxy', gasSwapProxy);
+        emit log_named_uint('Gas via direct Permit2', gasDirect);
     }
 }

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -624,4 +624,48 @@ contract BalanceSwapProxyTest is Test {
         assertEq(tokenB.balanceOf(address(router)), 0);
         assertGt(tokenB.balanceOf(RECIPIENT), 0);
     }
+
+    // ---------- native output ----------
+
+    /// @dev tokenOut = address(0): route swaps A -> WETH into the router, unwraps to the
+    ///      recipient; the proxy floor-checks the recipient's ETH balance delta.
+    function testSignedNativeOutput() public {
+        // fund a tokenA/WETH pair
+        address pairAW = FACTORY.createPair(address(tokenA), address(WETH9));
+        tokenA.mint(pairAW, 100 ether);
+        vm.deal(address(this), 100 ether);
+        (bool ok,) = address(WETH9).call{value: 100 ether}('');
+        require(ok, 'weth deposit failed');
+        WETH9.transfer(pairAW, 100 ether);
+        IUniswapV2Pair(pairAW).sync();
+
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
+        tokenA.approve(address(PERMIT2), type(uint256).max);
+        vm.stopPrank();
+
+        // route: V2 swap A -> WETH with recipient ADDRESS_THIS (the router), then UNWRAP_WETH to RECIPIENT
+        bytes memory commands =
+            abi.encodePacked(bytes1(uint8(Commands.V2_SWAP_EXACT_IN)), bytes1(uint8(Commands.UNWRAP_WETH)));
+        address[] memory path = new address[](2);
+        path[0] = address(tokenA);
+        path[1] = address(WETH9);
+        bytes[] memory inputs = new bytes[](2);
+        inputs[0] = abi.encode(
+            ActionConstants.ADDRESS_THIS, ActionConstants.CONTRACT_BALANCE, 0, path, false, new uint256[](0)
+        );
+        inputs[1] = abi.encode(RECIPIENT, 0);
+
+        IBalanceSwapProxy.SwapIntent memory intent = _intent(address(0), RECIPIENT, 0.9e36, 0);
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            _permit(address(tokenA), type(uint256).max, 42, block.timestamp + 1000);
+        bytes memory sig = _signIntent(permit, intent, commands, inputs, OWNER_KEY);
+
+        uint256 ethBefore = RECIPIENT.balance;
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+
+        assertGt(RECIPIENT.balance - ethBefore, 0.9 ether, 'recipient received native ETH above floor');
+        assertEq(WETH9.balanceOf(address(router)), 0, 'no WETH residue');
+        assertEq(address(router).balance, 0, 'no ETH residue');
+    }
 }

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -217,4 +217,39 @@ contract BalanceSwapProxyTest is Test {
         );
         vm.stopPrank();
     }
+
+    // ---------- Mode 2b: direct, Permit2 allowance ----------
+
+    function testPermit2AllowanceExecuteSwapsFullBalance() public {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
+        tokenA.approve(address(PERMIT2), type(uint256).max);
+        PERMIT2.approve(address(tokenA), address(proxy), type(uint160).max, type(uint48).max);
+
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        uint256 expectedOut = _expectedOut(AMOUNT, pairAB, address(tokenA));
+
+        proxy.executeWithPermit2Allowance(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, 0.9e36, 0), commands, inputs, block.timestamp + 1000
+        );
+        vm.stopPrank();
+
+        assertEq(tokenA.balanceOf(OWNER), 0);
+        assertEq(tokenB.balanceOf(RECIPIENT), expectedOut);
+        assertEq(tokenA.balanceOf(address(router)), 0);
+        assertEq(tokenA.balanceOf(address(proxy)), 0);
+    }
+
+    function testPermit2AllowanceRevertsWithoutPermit2Approval() public {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
+        tokenA.approve(address(PERMIT2), type(uint256).max);
+        // note: no PERMIT2.approve(tokenA, proxy, ...) — the proxy has no allowance
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        vm.expectRevert();
+        proxy.executeWithPermit2Allowance(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, 0, 0), commands, inputs, block.timestamp + 1000
+        );
+        vm.stopPrank();
+    }
 }

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -31,6 +31,7 @@ error SignatureExpired(uint256 signatureDeadline);
 contract BalanceSwapProxyTest is Test {
     uint256 constant AMOUNT = 1 ether;
     uint256 constant BALANCE = 100000 ether;
+    uint256 constant FIXTURE_NONCE = 1;
     IUniswapV2Factory constant FACTORY = IUniswapV2Factory(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
     ERC20 constant WETH9 = ERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     IPermit2 constant PERMIT2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
@@ -49,20 +50,7 @@ contract BalanceSwapProxyTest is Test {
         vm.createSelectFork(vm.envString('FORK_URL'), 20010000);
         OWNER = vm.addr(OWNER_KEY);
 
-        RouterParameters memory params = RouterParameters({
-            permit2: address(PERMIT2),
-            weth9: address(WETH9),
-            v2Factory: address(FACTORY),
-            v3Factory: address(0),
-            pairInitCodeHash: bytes32(0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f),
-            poolInitCodeHash: bytes32(0),
-            v4PoolManager: address(0),
-            permissionsAdapterFactory: address(0),
-            v3NFTPositionManager: address(0),
-            v4PositionManager: address(0),
-            spokePool: address(0)
-        });
-        router = new UniversalRouter(params);
+        router = new UniversalRouter(_routerParams());
         proxy = new BalanceSwapProxy(PERMIT2);
 
         tokenA = new MockERC20();
@@ -78,6 +66,22 @@ contract BalanceSwapProxyTest is Test {
     }
 
     // ---------- shared helpers ----------
+
+    function _routerParams() internal view returns (RouterParameters memory) {
+        return RouterParameters({
+            permit2: address(PERMIT2),
+            weth9: address(WETH9),
+            v2Factory: address(FACTORY),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            permissionsAdapterFactory: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0),
+            spokePool: address(0)
+        });
+    }
 
     function _v2Route(address tokenIn_, address tokenOut_, address recipient_)
         internal
@@ -250,15 +254,14 @@ contract BalanceSwapProxyTest is Test {
         );
         vm.stopPrank();
 
-        assertEq(tokenA.balanceOf(OWNER), 0);
-        assertEq(tokenB.balanceOf(RECIPIENT), expectedOut);
-        assertEq(tokenA.balanceOf(address(router)), 0);
-        assertEq(tokenA.balanceOf(address(proxy)), 0);
+        assertEq(tokenA.balanceOf(OWNER), 0, 'full balance consumed');
+        assertEq(tokenB.balanceOf(RECIPIENT), expectedOut, 'recipient got the output');
+        assertEq(tokenA.balanceOf(address(router)), 0, 'no residue in router');
+        assertEq(tokenA.balanceOf(address(proxy)), 0, 'no residue in proxy');
     }
 
     function testPermit2AllowanceRevertsWithoutPermit2Approval() public {
         vm.startPrank(OWNER);
-        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
         tokenA.approve(address(PERMIT2), type(uint256).max);
         // note: no PERMIT2.approve(tokenA, proxy, ...) — the proxy has no allowance
         (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
@@ -380,7 +383,7 @@ contract BalanceSwapProxyTest is Test {
 
     /// @dev Signs a default intent over the canonical A->B route. Returns everything a test
     ///      needs to execute or tamper.
-    function _signedFixture(uint256 cap, uint256 minAmount, uint256 nonce)
+    function _signedFixture(uint256 cap, uint256 minAmount)
         internal
         returns (
             ISignatureTransfer.PermitTransferFrom memory permit,
@@ -397,7 +400,7 @@ contract BalanceSwapProxyTest is Test {
 
         (commands, inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
         intent = _intent(address(tokenB), RECIPIENT, 0.9e36, minAmount);
-        permit = _permit(address(tokenA), cap, nonce, block.timestamp + 1000);
+        permit = _permit(address(tokenA), cap, FIXTURE_NONCE, block.timestamp + 1000);
         sig = _signIntent(permit, intent, commands, inputs, OWNER_KEY);
     }
 
@@ -407,7 +410,7 @@ contract BalanceSwapProxyTest is Test {
             IBalanceSwapProxy.SwapIntent memory intent,,
             bytes[] memory inputs,
             bytes memory sig
-        ) = _signedFixture(type(uint256).max, 0, 10);
+        ) = _signedFixture(type(uint256).max, 0);
 
         // relayer swaps in a different (valid-looking) command byte
         bytes memory tampered = abi.encodePacked(bytes1(uint8(Commands.V2_SWAP_EXACT_OUT)));
@@ -422,7 +425,7 @@ contract BalanceSwapProxyTest is Test {
             bytes memory commands,
             bytes[] memory inputs,
             bytes memory sig
-        ) = _signedFixture(type(uint256).max, 0, 11);
+        ) = _signedFixture(type(uint256).max, 0);
 
         // relayer redirects the swap output to themselves
         address[] memory path = new address[](2);
@@ -440,7 +443,7 @@ contract BalanceSwapProxyTest is Test {
             bytes memory commands,
             bytes[] memory inputs,
             bytes memory sig
-        ) = _signedFixture(type(uint256).max, 0.1 ether, 12);
+        ) = _signedFixture(type(uint256).max, 0.1 ether);
 
         IBalanceSwapProxy.SwapIntent memory tampered;
 
@@ -475,7 +478,7 @@ contract BalanceSwapProxyTest is Test {
             IBalanceSwapProxy.SwapIntent memory intent,
             bytes memory commands,
             bytes[] memory inputs,
-        ) = _signedFixture(type(uint256).max, 0, 13);
+        ) = _signedFixture(type(uint256).max, 0);
 
         bytes memory wrongSig = _signIntent(permit, intent, commands, inputs, 0xBEE1); // not OWNER_KEY
         vm.expectRevert(SignatureVerification.InvalidSigner.selector);
@@ -489,7 +492,7 @@ contract BalanceSwapProxyTest is Test {
             bytes memory commands,
             bytes[] memory inputs,
             bytes memory sig
-        ) = _signedFixture(type(uint256).max, 0, 17);
+        ) = _signedFixture(type(uint256).max, 0);
 
         // a different address with a balance (so _resolveAmount passes and Permit2 verification is reached)
         address notTheSigner = address(0xDA2E);
@@ -506,7 +509,7 @@ contract BalanceSwapProxyTest is Test {
             bytes memory commands,
             bytes[] memory inputs,
             bytes memory sig
-        ) = _signedFixture(0.1 ether, 0.5 ether, 18); // cap 0.1, minAmount 0.5; OWNER holds 1 ether
+        ) = _signedFixture(0.1 ether, 0.5 ether); // cap 0.1, minAmount 0.5; OWNER holds 1 ether
 
         vm.expectRevert(abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.1 ether, 0.5 ether));
         proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
@@ -519,7 +522,7 @@ contract BalanceSwapProxyTest is Test {
             bytes memory commands,
             bytes[] memory inputs,
             bytes memory sig
-        ) = _signedFixture(type(uint256).max, 0, 14);
+        ) = _signedFixture(type(uint256).max, 0);
 
         proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
 
@@ -536,7 +539,7 @@ contract BalanceSwapProxyTest is Test {
             bytes memory commands,
             bytes[] memory inputs,
             bytes memory sig
-        ) = _signedFixture(type(uint256).max, 0, 15);
+        ) = _signedFixture(type(uint256).max, 0);
 
         vm.warp(block.timestamp + 2000); // past permit.deadline
         vm.expectRevert(abi.encodeWithSelector(SignatureExpired.selector, permit.deadline));
@@ -575,7 +578,7 @@ contract BalanceSwapProxyTest is Test {
     /// @dev A floor-revert consumes nothing; the same signature succeeds after the price improves.
     function testSignedFloorRevertPreservesSignature() public {
         (ISignatureTransfer.PermitTransferFrom memory permit,, bytes memory commands, bytes[] memory inputs,) =
-            _signedFixture(type(uint256).max, 0, 16);
+            _signedFixture(type(uint256).max, 0);
 
         // sign a floor just above the currently-achievable rate
         uint256 expectedOut = _expectedOut(AMOUNT, pairAB, address(tokenA));
@@ -716,20 +719,7 @@ contract BalanceSwapProxyTest is Test {
     ///      is stranded. Proves the proxy carries no cross-call state.
     function testReentryThroughSecondRouterIsIndependent() public {
         // second router, same params as setUp
-        RouterParameters memory params = RouterParameters({
-            permit2: address(PERMIT2),
-            weth9: address(WETH9),
-            v2Factory: address(FACTORY),
-            v3Factory: address(0),
-            pairInitCodeHash: bytes32(0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f),
-            poolInitCodeHash: bytes32(0),
-            v4PoolManager: address(0),
-            permissionsAdapterFactory: address(0),
-            v3NFTPositionManager: address(0),
-            v4PositionManager: address(0),
-            spokePool: address(0)
-        });
-        UniversalRouter router2 = new UniversalRouter(params);
+        UniversalRouter router2 = new UniversalRouter(_routerParams());
 
         // outer swap: tokenA -> EVIL (pair funded below)
         ReenteringERC20 evil = new ReenteringERC20();
@@ -761,6 +751,8 @@ contract BalanceSwapProxyTest is Test {
         tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
         tokenA.approve(address(proxy), type(uint256).max);
         (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(evil), RECIPIENT);
+        uint256 expectedOuter = _expectedOut(AMOUNT, pairAE, address(tokenA));
+        uint256 expectedInner = _expectedOut(AMOUNT, pairAB, address(tokenB));
         proxy.execute(
             address(tokenA),
             IBalanceSwapProxy.SwapIntent({
@@ -777,12 +769,15 @@ contract BalanceSwapProxyTest is Test {
         vm.stopPrank();
 
         // both executions landed; nothing stranded anywhere
-        assertGt(evil.balanceOf(RECIPIENT), 0, 'outer output delivered');
-        assertGt(tokenA.balanceOf(RECIPIENT2), 0, 'inner output delivered');
+        assertEq(evil.balanceOf(RECIPIENT), expectedOuter, 'outer output delivered');
+        assertEq(tokenA.balanceOf(RECIPIENT2), expectedInner, 'inner output delivered');
         assertEq(tokenA.balanceOf(address(proxy)), 0);
         assertEq(tokenB.balanceOf(address(proxy)), 0);
         assertEq(tokenA.balanceOf(address(router)), 0);
         assertEq(tokenB.balanceOf(address(router2)), 0);
+        assertEq(evil.balanceOf(address(router)), 0);
+        assertEq(tokenA.balanceOf(address(router2)), 0);
+        assertEq(evil.balanceOf(address(proxy)), 0);
     }
 
     // ---------- gas ----------

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -14,6 +14,15 @@ import {IBalanceSwapProxy} from '../../contracts/interfaces/IBalanceSwapProxy.so
 import {Commands} from '../../contracts/libraries/Commands.sol';
 import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
 import {MockERC20} from './mock/MockERC20.sol';
+import {SignatureVerification} from 'permit2/src/libraries/SignatureVerification.sol';
+
+// NOTE: permit2/src/PermitErrors.sol is pinned to an exact `pragma solidity 0.8.17;`, which is
+// incompatible with this repo's pinned `solc_version = 0.8.26` (foundry.toml) and fails the
+// build the moment anything imports it. SignatureVerification.sol (imported above) has a
+// permissive `^0.8.17` pragma and compiles fine. These two errors are redeclared locally,
+// verbatim from PermitErrors.sol, so their selectors match exactly without importing that file.
+error InvalidNonce();
+error SignatureExpired(uint256 signatureDeadline);
 
 contract BalanceSwapProxyTest is Test {
     uint256 constant AMOUNT = 1 ether;
@@ -358,5 +367,192 @@ contract BalanceSwapProxyTest is Test {
 
         assertEq(tokenA.balanceOf(OWNER), 1 ether, 'excess above cap untouched');
         assertGt(tokenB.balanceOf(RECIPIENT), 0);
+    }
+
+    // ---------- Mode 1: adversarial relayer, replay, dust-grief, retry ----------
+
+    /// @dev Signs a default intent over the canonical A->B route. Returns everything a test
+    ///      needs to execute or tamper.
+    function _signedFixture(uint256 cap, uint256 minAmount, uint256 nonce)
+        internal
+        returns (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands,
+            bytes[] memory inputs,
+            bytes memory sig
+        )
+    {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
+        tokenA.approve(address(PERMIT2), type(uint256).max);
+        vm.stopPrank();
+
+        (commands, inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        intent = _intent(address(tokenB), RECIPIENT, 0.9e36, minAmount);
+        permit = _permit(address(tokenA), cap, nonce, block.timestamp + 1000);
+        sig = _signIntent(permit, intent, commands, inputs, OWNER_KEY);
+    }
+
+    function testSignedRevertsOnTamperedCommands() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,,
+            bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 10);
+
+        // relayer swaps in a different (valid-looking) command byte
+        bytes memory tampered = abi.encodePacked(bytes1(uint8(Commands.V2_SWAP_EXACT_OUT)));
+        vm.expectRevert(SignatureVerification.InvalidSigner.selector);
+        proxy.executeWithSig(permit, sig, OWNER, intent, tampered, inputs);
+    }
+
+    function testSignedRevertsOnTamperedInputs() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands, bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 11);
+
+        // relayer redirects the swap output to themselves
+        address[] memory path = new address[](2);
+        path[0] = address(tokenA);
+        path[1] = address(tokenB);
+        inputs[0] = abi.encode(address(0xBAD), ActionConstants.CONTRACT_BALANCE, 0, path, false, new uint256[](0));
+        vm.expectRevert(SignatureVerification.InvalidSigner.selector);
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+    }
+
+    function testSignedRevertsOnTamperedIntentFields() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands, bytes[] memory inputs, bytes memory sig) =
+            _signedFixture(type(uint256).max, 0.1 ether, 12);
+
+        IBalanceSwapProxy.SwapIntent memory tampered;
+
+        // lower the floor
+        tampered = intent;
+        tampered.minPriceX36 = 1;
+        vm.expectRevert(SignatureVerification.InvalidSigner.selector);
+        proxy.executeWithSig(permit, sig, OWNER, tampered, commands, inputs);
+
+        // change the recipient
+        tampered = intent;
+        tampered.recipient = address(0xBAD);
+        vm.expectRevert(SignatureVerification.InvalidSigner.selector);
+        proxy.executeWithSig(permit, sig, OWNER, tampered, commands, inputs);
+
+        // change the router
+        tampered = intent;
+        tampered.router = address(0xBAD);
+        vm.expectRevert(SignatureVerification.InvalidSigner.selector);
+        proxy.executeWithSig(permit, sig, OWNER, tampered, commands, inputs);
+
+        // drop the minAmount gate (fixture signs minAmount = 0.1 ether so this tamper changes the hash)
+        tampered = intent;
+        tampered.minAmount = 0;
+        vm.expectRevert(SignatureVerification.InvalidSigner.selector);
+        proxy.executeWithSig(permit, sig, OWNER, tampered, commands, inputs);
+    }
+
+    function testSignedRevertsOnWrongSigner() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands, bytes[] memory inputs,) = _signedFixture(type(uint256).max, 0, 13);
+
+        bytes memory wrongSig = _signIntent(permit, intent, commands, inputs, 0xBEE1); // not OWNER_KEY
+        vm.expectRevert(SignatureVerification.InvalidSigner.selector);
+        proxy.executeWithSig(permit, wrongSig, OWNER, intent, commands, inputs);
+    }
+
+    function testSignedRevertsOnWrongOwner() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands, bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 17);
+
+        // a different address with a balance (so _resolveAmount passes and Permit2 verification is reached)
+        address notTheSigner = address(0xDA2E);
+        tokenA.mint(notTheSigner, AMOUNT);
+        vm.expectRevert(SignatureVerification.InvalidSigner.selector);
+        proxy.executeWithSig(permit, sig, notTheSigner, intent, commands, inputs);
+    }
+
+    /// @dev Signer contradiction: cap below minAmount can never execute — the capped amount fails the gate.
+    function testSignedRevertsWhenCapBelowMinAmount() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands, bytes[] memory inputs, bytes memory sig) =
+            _signedFixture(0.1 ether, 0.5 ether, 18); // cap 0.1, minAmount 0.5; OWNER holds 1 ether
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.1 ether, 0.5 ether)
+        );
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+    }
+
+    function testSignedRevertsOnReplay() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands, bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 14);
+
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+
+        // refill and replay the same signature
+        tokenA.mint(OWNER, AMOUNT);
+        vm.expectRevert(InvalidNonce.selector);
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+    }
+
+    function testSignedRevertsOnExpiredDeadline() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands, bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 15);
+
+        vm.warp(block.timestamp + 2000); // past permit.deadline
+        vm.expectRevert(abi.encodeWithSelector(SignatureExpired.selector, permit.deadline));
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+    }
+
+    /// @dev The dust-grief story: attacker donates dust pre-fill; minAmount blocks execution and
+    ///      preserves the nonce; the real fill then executes with the same signature.
+    function testSignedDustGriefBlockedByMinAmount() public {
+        // fresh user with zero balance ("bridge hasn't filled yet")
+        uint256 userKey = 0xB0B2;
+        address user = vm.addr(userKey);
+        vm.prank(user);
+        tokenA.approve(address(PERMIT2), type(uint256).max);
+
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        IBalanceSwapProxy.SwapIntent memory intent = _intent(address(tokenB), RECIPIENT, 0.9e36, 0.5 ether);
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            _permit(address(tokenA), type(uint256).max, 99, block.timestamp + 1000);
+        bytes memory sig = _signIntent(permit, intent, commands, inputs, userKey);
+
+        // attacker donates dust and tries to burn the intent
+        tokenA.mint(user, 0.01 ether);
+        vm.prank(address(0xA77AC4E4));
+        vm.expectRevert(
+            abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.01 ether, 0.5 ether)
+        );
+        proxy.executeWithSig(permit, sig, user, intent, commands, inputs);
+
+        // the bridge fills; the SAME signature now executes
+        tokenA.mint(user, AMOUNT);
+        vm.prank(address(0xF177E4));
+        proxy.executeWithSig(permit, sig, user, intent, commands, inputs);
+        assertEq(tokenA.balanceOf(user), 0);
+        assertGt(tokenB.balanceOf(RECIPIENT), 0);
+    }
+
+    /// @dev A floor-revert consumes nothing; the same signature succeeds after the price improves.
+    function testSignedFloorRevertPreservesSignature() public {
+        (ISignatureTransfer.PermitTransferFrom memory permit,, bytes memory commands, bytes[] memory inputs,) =
+            _signedFixture(type(uint256).max, 0, 16);
+
+        // sign a floor just above the currently-achievable rate
+        uint256 expectedOut = _expectedOut(AMOUNT, pairAB, address(tokenA));
+        IBalanceSwapProxy.SwapIntent memory intent =
+            _intent(address(tokenB), RECIPIENT, (expectedOut + 2) * 1e18, 0);
+        bytes memory sig = _signIntent(permit, intent, commands, inputs, OWNER_KEY);
+
+        vm.expectRevert(); // InsufficientOutput
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+        assertEq(tokenA.balanceOf(OWNER), AMOUNT, 'pull unwound atomically');
+
+        // pool price improves (one-sided tokenB donation + sync raises the A->B rate)
+        tokenB.mint(pairAB, 10 ether);
+        IUniswapV2Pair(pairAB).sync();
+
+        proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
+        assertEq(tokenA.balanceOf(OWNER), 0, 'same signature executed after retry');
     }
 }

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -162,12 +162,9 @@ contract BalanceSwapProxyTest is Test {
         tokenA.transfer(address(0xDEAD), BALANCE - 0.01 ether); // leave dust
         tokenA.approve(address(proxy), type(uint256).max);
         (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
-        vm.expectRevert(
-            abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.01 ether, 0.5 ether)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.01 ether, 0.5 ether));
         proxy.execute(
-            address(tokenA), _intent(address(tokenB), RECIPIENT, 0, 0.5 ether), commands, inputs,
-            block.timestamp + 1000
+            address(tokenA), _intent(address(tokenB), RECIPIENT, 0, 0.5 ether), commands, inputs, block.timestamp + 1000
         );
         vm.stopPrank();
     }
@@ -183,7 +180,10 @@ contract BalanceSwapProxyTest is Test {
 
         // floor == expectedOut exactly: passes
         proxy.execute(
-            address(tokenA), _intent(address(tokenB), RECIPIENT, expectedOut * 1e18, 0), commands, inputs,
+            address(tokenA),
+            _intent(address(tokenB), RECIPIENT, expectedOut * 1e18, 0),
+            commands,
+            inputs,
             block.timestamp + 1000
         );
         assertEq(tokenB.balanceOf(RECIPIENT), expectedOut);
@@ -202,7 +202,10 @@ contract BalanceSwapProxyTest is Test {
             abi.encodeWithSelector(IBalanceSwapProxy.InsufficientOutput.selector, expectedOut, expectedOut + 1)
         );
         proxy.execute(
-            address(tokenA), _intent(address(tokenB), RECIPIENT, (expectedOut + 1) * 1e18, 0), commands, inputs,
+            address(tokenA),
+            _intent(address(tokenB), RECIPIENT, (expectedOut + 1) * 1e18, 0),
+            commands,
+            inputs,
             block.timestamp + 1000
         );
         vm.stopPrank();
@@ -399,8 +402,12 @@ contract BalanceSwapProxyTest is Test {
     }
 
     function testSignedRevertsOnTamperedCommands() public {
-        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,,
-            bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 10);
+        (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,,
+            bytes[] memory inputs,
+            bytes memory sig
+        ) = _signedFixture(type(uint256).max, 0, 10);
 
         // relayer swaps in a different (valid-looking) command byte
         bytes memory tampered = abi.encodePacked(bytes1(uint8(Commands.V2_SWAP_EXACT_OUT)));
@@ -409,8 +416,13 @@ contract BalanceSwapProxyTest is Test {
     }
 
     function testSignedRevertsOnTamperedInputs() public {
-        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
-            bytes memory commands, bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 11);
+        (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands,
+            bytes[] memory inputs,
+            bytes memory sig
+        ) = _signedFixture(type(uint256).max, 0, 11);
 
         // relayer redirects the swap output to themselves
         address[] memory path = new address[](2);
@@ -422,9 +434,13 @@ contract BalanceSwapProxyTest is Test {
     }
 
     function testSignedRevertsOnTamperedIntentFields() public {
-        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
-            bytes memory commands, bytes[] memory inputs, bytes memory sig) =
-            _signedFixture(type(uint256).max, 0.1 ether, 12);
+        (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands,
+            bytes[] memory inputs,
+            bytes memory sig
+        ) = _signedFixture(type(uint256).max, 0.1 ether, 12);
 
         IBalanceSwapProxy.SwapIntent memory tampered;
 
@@ -454,8 +470,12 @@ contract BalanceSwapProxyTest is Test {
     }
 
     function testSignedRevertsOnWrongSigner() public {
-        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
-            bytes memory commands, bytes[] memory inputs,) = _signedFixture(type(uint256).max, 0, 13);
+        (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands,
+            bytes[] memory inputs,
+        ) = _signedFixture(type(uint256).max, 0, 13);
 
         bytes memory wrongSig = _signIntent(permit, intent, commands, inputs, 0xBEE1); // not OWNER_KEY
         vm.expectRevert(SignatureVerification.InvalidSigner.selector);
@@ -463,8 +483,13 @@ contract BalanceSwapProxyTest is Test {
     }
 
     function testSignedRevertsOnWrongOwner() public {
-        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
-            bytes memory commands, bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 17);
+        (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands,
+            bytes[] memory inputs,
+            bytes memory sig
+        ) = _signedFixture(type(uint256).max, 0, 17);
 
         // a different address with a balance (so _resolveAmount passes and Permit2 verification is reached)
         address notTheSigner = address(0xDA2E);
@@ -475,19 +500,26 @@ contract BalanceSwapProxyTest is Test {
 
     /// @dev Signer contradiction: cap below minAmount can never execute — the capped amount fails the gate.
     function testSignedRevertsWhenCapBelowMinAmount() public {
-        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
-            bytes memory commands, bytes[] memory inputs, bytes memory sig) =
-            _signedFixture(0.1 ether, 0.5 ether, 18); // cap 0.1, minAmount 0.5; OWNER holds 1 ether
+        (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands,
+            bytes[] memory inputs,
+            bytes memory sig
+        ) = _signedFixture(0.1 ether, 0.5 ether, 18); // cap 0.1, minAmount 0.5; OWNER holds 1 ether
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.1 ether, 0.5 ether)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.1 ether, 0.5 ether));
         proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
     }
 
     function testSignedRevertsOnReplay() public {
-        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
-            bytes memory commands, bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 14);
+        (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands,
+            bytes[] memory inputs,
+            bytes memory sig
+        ) = _signedFixture(type(uint256).max, 0, 14);
 
         proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
 
@@ -498,8 +530,13 @@ contract BalanceSwapProxyTest is Test {
     }
 
     function testSignedRevertsOnExpiredDeadline() public {
-        (ISignatureTransfer.PermitTransferFrom memory permit, IBalanceSwapProxy.SwapIntent memory intent,
-            bytes memory commands, bytes[] memory inputs, bytes memory sig) = _signedFixture(type(uint256).max, 0, 15);
+        (
+            ISignatureTransfer.PermitTransferFrom memory permit,
+            IBalanceSwapProxy.SwapIntent memory intent,
+            bytes memory commands,
+            bytes[] memory inputs,
+            bytes memory sig
+        ) = _signedFixture(type(uint256).max, 0, 15);
 
         vm.warp(block.timestamp + 2000); // past permit.deadline
         vm.expectRevert(abi.encodeWithSelector(SignatureExpired.selector, permit.deadline));
@@ -524,9 +561,7 @@ contract BalanceSwapProxyTest is Test {
         // attacker donates dust and tries to burn the intent
         tokenA.mint(user, 0.01 ether);
         vm.prank(address(0xA77AC4E4));
-        vm.expectRevert(
-            abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.01 ether, 0.5 ether)
-        );
+        vm.expectRevert(abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.01 ether, 0.5 ether));
         proxy.executeWithSig(permit, sig, user, intent, commands, inputs);
 
         // the bridge fills; the SAME signature now executes
@@ -544,8 +579,7 @@ contract BalanceSwapProxyTest is Test {
 
         // sign a floor just above the currently-achievable rate
         uint256 expectedOut = _expectedOut(AMOUNT, pairAB, address(tokenA));
-        IBalanceSwapProxy.SwapIntent memory intent =
-            _intent(address(tokenB), RECIPIENT, (expectedOut + 2) * 1e18, 0);
+        IBalanceSwapProxy.SwapIntent memory intent = _intent(address(tokenB), RECIPIENT, (expectedOut + 2) * 1e18, 0);
         bytes memory sig = _signIntent(permit, intent, commands, inputs, OWNER_KEY);
 
         vm.expectRevert(); // InsufficientOutput
@@ -592,7 +626,10 @@ contract BalanceSwapProxyTest is Test {
         // BALANCE * uint256.max overflows in _checkOutput -> arithmetic panic, not a wrap
         vm.expectRevert(stdError.arithmeticError);
         proxy.execute(
-            address(tokenA), _intent(address(tokenB), RECIPIENT, type(uint256).max, 0), commands, inputs,
+            address(tokenA),
+            _intent(address(tokenB), RECIPIENT, type(uint256).max, 0),
+            commands,
+            inputs,
             block.timestamp + 1000
         );
         vm.stopPrank();
@@ -709,11 +746,7 @@ contract BalanceSwapProxyTest is Test {
         (bytes memory innerCommands, bytes[] memory innerInputs) =
             _v2Route(address(tokenB), address(tokenA), RECIPIENT2);
         IBalanceSwapProxy.SwapIntent memory innerIntent = IBalanceSwapProxy.SwapIntent({
-            router: address(router2),
-            tokenOut: address(tokenA),
-            recipient: RECIPIENT2,
-            minPriceX36: 0,
-            minAmount: 0
+            router: address(router2), tokenOut: address(tokenA), recipient: RECIPIENT2, minPriceX36: 0, minAmount: 0
         });
         evil.arm(
             address(proxy),
@@ -772,9 +805,7 @@ contract BalanceSwapProxyTest is Test {
         tokenA.transfer(address(0xDEAD), 2 * AMOUNT);
         (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), user);
         uint256 gasBefore = gasleft();
-        proxy.execute(
-            address(tokenA), _intent(address(tokenB), user, 0, 0), commands, inputs, block.timestamp + 1000
-        );
+        proxy.execute(address(tokenA), _intent(address(tokenB), user, 0, 0), commands, inputs, block.timestamp + 1000);
         uint256 gasBalanceProxy = gasBefore - gasleft();
 
         // 2. SwapProxy (exact amount)
@@ -783,8 +814,7 @@ contract BalanceSwapProxyTest is Test {
         exactInputs[0] = abi.encode(user, AMOUNT, 0, path, false, new uint256[](0));
         gasBefore = gasleft();
         swapProxy.execute(
-            IUniversalRouter(address(router)), address(tokenA), AMOUNT, commands, exactInputs,
-            block.timestamp + 1000
+            IUniversalRouter(address(router)), address(tokenA), AMOUNT, commands, exactInputs, block.timestamp + 1000
         );
         uint256 gasSwapProxy = gasBefore - gasleft();
 

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import 'forge-std/Test.sol';
+import {IPermit2} from 'permit2/src/interfaces/IPermit2.sol';
+import {ISignatureTransfer} from 'permit2/src/interfaces/ISignatureTransfer.sol';
+import {ERC20} from 'solmate/src/tokens/ERC20.sol';
+import {IUniswapV2Factory} from '@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol';
+import {IUniswapV2Pair} from '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';
+import {ActionConstants} from '@uniswap/v4-periphery/src/libraries/ActionConstants.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {BalanceSwapProxy} from '../../contracts/BalanceSwapProxy.sol';
+import {IBalanceSwapProxy} from '../../contracts/interfaces/IBalanceSwapProxy.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {MockERC20} from './mock/MockERC20.sol';
+
+contract BalanceSwapProxyTest is Test {
+    uint256 constant AMOUNT = 1 ether;
+    uint256 constant BALANCE = 100000 ether;
+    IUniswapV2Factory constant FACTORY = IUniswapV2Factory(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
+    ERC20 constant WETH9 = ERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    IPermit2 constant PERMIT2 = IPermit2(0x000000000022D473030F116dDEE9F6B43aC78BA3);
+
+    uint256 constant OWNER_KEY = 0xA11CE;
+    address OWNER;
+    address RECIPIENT = address(0x4EC1);
+
+    UniversalRouter router;
+    BalanceSwapProxy proxy;
+    MockERC20 tokenA;
+    MockERC20 tokenB;
+    address pairAB;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString('FORK_URL'), 20010000);
+        OWNER = vm.addr(OWNER_KEY);
+
+        RouterParameters memory params = RouterParameters({
+            permit2: address(PERMIT2),
+            weth9: address(WETH9),
+            v2Factory: address(FACTORY),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            permissionsAdapterFactory: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0),
+            spokePool: address(0)
+        });
+        router = new UniversalRouter(params);
+        proxy = new BalanceSwapProxy(PERMIT2);
+
+        tokenA = new MockERC20();
+        tokenB = new MockERC20();
+        if (address(tokenA) > address(tokenB)) (tokenA, tokenB) = (tokenB, tokenA);
+
+        pairAB = FACTORY.createPair(address(tokenA), address(tokenB));
+        tokenA.mint(pairAB, 100 ether);
+        tokenB.mint(pairAB, 100 ether);
+        IUniswapV2Pair(pairAB).sync();
+
+        tokenA.mint(OWNER, BALANCE);
+    }
+
+    // ---------- shared helpers ----------
+
+    function _v2Route(address tokenIn_, address tokenOut_, address recipient_)
+        internal
+        pure
+        returns (bytes memory commands, bytes[] memory inputs)
+    {
+        commands = abi.encodePacked(bytes1(uint8(Commands.V2_SWAP_EXACT_IN)));
+        address[] memory path = new address[](2);
+        path[0] = tokenIn_;
+        path[1] = tokenOut_;
+        inputs = new bytes[](1);
+        // recipient explicit, amountIn = CONTRACT_BALANCE, payerIsUser = false
+        inputs[0] = abi.encode(recipient_, ActionConstants.CONTRACT_BALANCE, 0, path, false, new uint256[](0));
+    }
+
+    function _intent(address tokenOut_, address recipient_, uint256 minPriceX36_, uint256 minAmount_)
+        internal
+        view
+        returns (IBalanceSwapProxy.SwapIntent memory)
+    {
+        return IBalanceSwapProxy.SwapIntent({
+            router: address(router),
+            tokenOut: tokenOut_,
+            recipient: recipient_,
+            minPriceX36: minPriceX36_,
+            minAmount: minAmount_
+        });
+    }
+
+    function _expectedOut(uint256 amountIn, address pairAddr, address tokenIn_) internal view returns (uint256) {
+        (uint112 r0, uint112 r1,) = IUniswapV2Pair(pairAddr).getReserves();
+        (uint256 rin, uint256 rout) =
+            tokenIn_ == IUniswapV2Pair(pairAddr).token0() ? (uint256(r0), uint256(r1)) : (uint256(r1), uint256(r0));
+        return amountIn * 997 * rout / (rin * 1000 + amountIn * 997);
+    }
+
+    // ---------- Mode 2a: direct, ERC20 approval ----------
+
+    function testDirectExecuteSwapsFullBalance() public {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT); // leave exactly AMOUNT as the "full balance"
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        uint256 expectedOut = _expectedOut(AMOUNT, pairAB, address(tokenA));
+
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, 0.9e36, 0), commands, inputs, block.timestamp + 1000
+        );
+        vm.stopPrank();
+
+        assertEq(tokenA.balanceOf(OWNER), 0, 'full balance consumed');
+        assertEq(tokenB.balanceOf(RECIPIENT), expectedOut, 'recipient got the output');
+        assertEq(tokenA.balanceOf(address(router)), 0, 'no residue in router');
+        assertEq(tokenA.balanceOf(address(proxy)), 0, 'no residue in proxy');
+    }
+}

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -120,4 +120,101 @@ contract BalanceSwapProxyTest is Test {
         assertEq(tokenA.balanceOf(address(router)), 0, 'no residue in router');
         assertEq(tokenA.balanceOf(address(proxy)), 0, 'no residue in proxy');
     }
+
+    function testDirectRevertsSameToken() public {
+        vm.startPrank(OWNER);
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenA), RECIPIENT);
+        vm.expectRevert(IBalanceSwapProxy.SameToken.selector);
+        proxy.execute(
+            address(tokenA), _intent(address(tokenA), RECIPIENT, 0, 0), commands, inputs, block.timestamp + 1000
+        );
+        vm.stopPrank();
+    }
+
+    function testDirectRevertsZeroBalance() public {
+        address broke = address(0xB0B);
+        vm.startPrank(broke);
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        vm.expectRevert(abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0, 0));
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, 0, 0), commands, inputs, block.timestamp + 1000
+        );
+        vm.stopPrank();
+    }
+
+    function testDirectRevertsBelowMinAmount() public {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - 0.01 ether); // leave dust
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        vm.expectRevert(
+            abi.encodeWithSelector(IBalanceSwapProxy.InsufficientBalance.selector, 0.01 ether, 0.5 ether)
+        );
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, 0, 0.5 ether), commands, inputs,
+            block.timestamp + 1000
+        );
+        vm.stopPrank();
+    }
+
+    /// @dev With amount = 1e18, floor = amount * minPriceX36 / 1e36 = minPriceX36 / 1e18 exactly —
+    ///      so minPriceX36 = expectedOut * 1e18 puts the floor at precisely expectedOut.
+    function testDirectFloorBoundaryExact() public {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        uint256 expectedOut = _expectedOut(AMOUNT, pairAB, address(tokenA));
+
+        // floor == expectedOut exactly: passes
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, expectedOut * 1e18, 0), commands, inputs,
+            block.timestamp + 1000
+        );
+        assertEq(tokenB.balanceOf(RECIPIENT), expectedOut);
+        vm.stopPrank();
+    }
+
+    function testDirectFloorBoundaryRevert() public {
+        vm.startPrank(OWNER);
+        tokenA.transfer(address(0xDEAD), BALANCE - AMOUNT);
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        uint256 expectedOut = _expectedOut(AMOUNT, pairAB, address(tokenA));
+
+        // floor == expectedOut + 1: reverts
+        vm.expectRevert(
+            abi.encodeWithSelector(IBalanceSwapProxy.InsufficientOutput.selector, expectedOut, expectedOut + 1)
+        );
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, (expectedOut + 1) * 1e18, 0), commands, inputs,
+            block.timestamp + 1000
+        );
+        vm.stopPrank();
+    }
+
+    function testDirectFloorDisabled() public {
+        // minPriceX36 = 0 skips the check even for an awful price (whole BALANCE into a small pool)
+        vm.startPrank(OWNER);
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, 0, 0), commands, inputs, block.timestamp + 1000
+        );
+        assertEq(tokenA.balanceOf(OWNER), 0);
+        assertGt(tokenB.balanceOf(RECIPIENT), 0);
+        vm.stopPrank();
+    }
+
+    function testDirectRevertsWithoutApproval() public {
+        vm.startPrank(OWNER);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        vm.expectRevert();
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, 0, 0), commands, inputs, block.timestamp + 1000
+        );
+        vm.stopPrank();
+    }
 }

--- a/test/foundry-tests/BalanceSwapProxy.t.sol
+++ b/test/foundry-tests/BalanceSwapProxy.t.sol
@@ -14,6 +14,7 @@ import {IBalanceSwapProxy} from '../../contracts/interfaces/IBalanceSwapProxy.so
 import {Commands} from '../../contracts/libraries/Commands.sol';
 import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
 import {MockERC20} from './mock/MockERC20.sol';
+import {MockERC20Decimals} from './mock/MockERC20Decimals.sol';
 import {SignatureVerification} from 'permit2/src/libraries/SignatureVerification.sol';
 
 // NOTE: permit2/src/PermitErrors.sol is pinned to an exact `pragma solidity 0.8.17;`, which is
@@ -554,5 +555,73 @@ contract BalanceSwapProxyTest is Test {
 
         proxy.executeWithSig(permit, sig, OWNER, intent, commands, inputs);
         assertEq(tokenA.balanceOf(OWNER), 0, 'same signature executed after retry');
+    }
+
+    // ---------- floor arithmetic ----------
+
+    /// @dev 6-dec in, 18-dec out: unit price 1.0 => base-unit rate 1e12 => minPriceX36 ~ 1e48.
+    ///      Proves the X36 width expresses extreme decimal asymmetry.
+    function testFloorAcrossDecimalAsymmetry() public {
+        MockERC20Decimals usdc = new MockERC20Decimals(6);
+        address pairU = FACTORY.createPair(address(usdc), address(tokenB));
+        usdc.mint(pairU, 100e6);
+        tokenB.mint(pairU, 100 ether);
+        IUniswapV2Pair(pairU).sync();
+
+        address user = address(0x6DEC);
+        vm.startPrank(user);
+        usdc.mint(user, 1e6); // 1 USDC
+        usdc.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(usdc), address(tokenB), RECIPIENT);
+
+        // floor = 1e6 * 0.9e48 / 1e36 = 0.9e18 — 0.9 tokenB out per 1 USDC in
+        proxy.execute(
+            address(usdc), _intent(address(tokenB), RECIPIENT, 0.9e48, 0), commands, inputs, block.timestamp + 1000
+        );
+        vm.stopPrank();
+        assertGt(tokenB.balanceOf(RECIPIENT), 0.9e18);
+    }
+
+    function testFloorOverflowReverts() public {
+        vm.startPrank(OWNER);
+        tokenA.approve(address(proxy), type(uint256).max);
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        // BALANCE * uint256.max overflows in _checkOutput -> arithmetic panic, not a wrap
+        vm.expectRevert(stdError.arithmeticError);
+        proxy.execute(
+            address(tokenA), _intent(address(tokenB), RECIPIENT, type(uint256).max, 0), commands, inputs,
+            block.timestamp + 1000
+        );
+        vm.stopPrank();
+    }
+
+    // ---------- residue invariant ----------
+
+    /// @dev After any successful signed execution, neither the proxy nor the router holds
+    ///      any of either token. Fuzzed over the delivered amount.
+    function testFuzzSignedNoResidue(uint256 amount) public {
+        amount = bound(amount, 1e6, 50 ether);
+
+        uint256 userKey = 0xFA22;
+        address user = vm.addr(userKey);
+        vm.startPrank(user);
+        tokenA.approve(address(PERMIT2), type(uint256).max);
+        vm.stopPrank();
+        tokenA.mint(user, amount);
+
+        (bytes memory commands, bytes[] memory inputs) = _v2Route(address(tokenA), address(tokenB), RECIPIENT);
+        IBalanceSwapProxy.SwapIntent memory intent = _intent(address(tokenB), RECIPIENT, 0, 0);
+        ISignatureTransfer.PermitTransferFrom memory permit =
+            _permit(address(tokenA), type(uint256).max, amount, block.timestamp + 1000); // nonce = amount (unique per run)
+        bytes memory sig = _signIntent(permit, intent, commands, inputs, userKey);
+
+        proxy.executeWithSig(permit, sig, user, intent, commands, inputs);
+
+        assertEq(tokenA.balanceOf(user), 0);
+        assertEq(tokenA.balanceOf(address(proxy)), 0);
+        assertEq(tokenB.balanceOf(address(proxy)), 0);
+        assertEq(tokenA.balanceOf(address(router)), 0);
+        assertEq(tokenB.balanceOf(address(router)), 0);
+        assertGt(tokenB.balanceOf(RECIPIENT), 0);
     }
 }

--- a/test/foundry-tests/mock/MockERC20Decimals.sol
+++ b/test/foundry-tests/mock/MockERC20Decimals.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {ERC20} from 'solmate/src/tokens/ERC20.sol';
+
+contract MockERC20Decimals is ERC20 {
+    constructor(uint8 _decimals) ERC20('MockD', 'MOCKD', _decimals) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/test/foundry-tests/mock/ReenteringERC20.sol
+++ b/test/foundry-tests/mock/ReenteringERC20.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {ERC20} from 'solmate/src/tokens/ERC20.sol';
+
+/// @dev ERC20 that makes one arbitrary call on its next transfer — simulates a token with
+///      hooks reentering mid-execution.
+contract ReenteringERC20 is ERC20('Evil', 'EVIL', 18) {
+    address public target;
+    bytes public payload;
+    bool internal armed;
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function arm(address _target, bytes calldata _payload) external {
+        target = _target;
+        payload = _payload;
+        armed = true;
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        bool ok = super.transfer(to, amount);
+        if (armed) {
+            armed = false;
+            (bool s,) = target.call(payload);
+            require(s, 'reenter call failed');
+        }
+        return ok;
+    }
+}


### PR DESCRIPTION
## Summary

Adds **BalanceSwapProxy**: a stateless, ownerless proxy that swaps a user's **entire then-current token balance** through the Universal Router. Sibling to `SwapProxy` (#469) — same fund-then-execute pattern (`payerIsUser=false`), but the amount is resolved at execution time instead of baked into calldata.

Primary use case: **bridge-and-swap**. Bridges deliver an unknown amount (bps-level relayer fee variance) minutes after the user signs. With this contract the user signs **once** at bridge initiation — a Permit2 `permitWitnessTransferFrom` whose witness binds the exact route — and anyone can relay the swap the moment funds land. No second signature, no exact amount known at sign time.

## Three entry points, one shared core

| Mode | Function | Auth | Gas payer |
|---|---|---|---|
| Signed & relayed | `executeWithSig` | Permit2 witness sig (single-use nonce) | anyone |
| Direct, ERC20 approval | `execute` | `approve(proxy)` + `msg.sender == owner` | owner |
| Direct, Permit2 allowance | `executeWithPermit2Allowance` | Permit2 AllowanceTransfer | owner |

Shared core: resolve `amount = min(balanceOf(owner), cap)` → require `amount ≥ minAmount` → pull **directly into the router** (proxy never custodies) → execute route → enforce rate floor on the recipient's output delta.

## Key design decisions

- **Route binding is cryptographic, not checked.** The proxy derives `routeHash = keccak256(abi.encode(commands, inputs))` and folds it into the Permit2 witness hash — a tampered route fails signature verification inside Permit2. There is no proxy-side route check to audit; the relayer is a pure gas payer.
- **Rate floor (`minPriceX36`, 1e36 fixed point — same convention as UR's `minHopPriceX36`), not absolute minOut.** The executed amount is the live balance, not the sign-time estimate; an absolute minOut mis-scales with any estimate/actual gap, a rate floor cannot.
- **`minAmount` anti-grief gate.** Without it, an attacker could donate dust to the owner pre-fill and execute the intent against it — a fair micro-swap passes a *rate* floor, consuming the single-use nonce and killing the intent while the user is offline. `minAmount` turns that grief into a donation.
- **Failure is graceful:** any revert unwinds the Permit2 pull atomically and does **not** consume the nonce; the same signature stays live for retry.

## Testing (28 Foundry fork tests)

- Happy paths ×3 modes; balance-below-cap and cap-below-balance amount resolution
- Adversarial relayer: tampered commands/inputs/every intent field, wrong signer, wrong owner → all fail Permit2 `InvalidSigner`
- Replay (`InvalidNonce`), expiry (`SignatureExpired`), dust-grief blocked + same-sig success after real fill, floor-revert unwind + same-sig retry after price improves
- Floor boundary exact-pass / off-by-one-revert, 6↔18 decimals asymmetry, overflow → checked-math revert
- Fuzzed no-residue invariant (proxy and router hold zero after any success)
- Native ETH output (`UNWRAP_WETH` route, ETH delta floor)
- Reentry statelessness via a second router; gas comparison (BalanceSwapProxy direct 123k vs SwapProxy 101k vs direct Permit2 94k)

Note: the test file deliberately duplicates the EIP-712 typestring rather than reading the contract's constants — self-referential tests would verify a typo'd typestring that no real wallet could sign.

## Also in this PR

- `fix: DeployTempo missing permissionsAdapterFactory` — `RouterParameters` gained the field in #476 but `DeployTempo` (#478) wasn't updated, breaking `forge` compilation on main.

## Follow-ups (tracked separately)

- SDK: `BALANCE_SWAP_PROXY_ADDRESS` registry + encode helper
- Trading service: witness permitData on `/quote`, new SwapType on `/swap`, state-override simulation
- **Full audit required before mainnet deployment** — this contract gates third-party-triggered movement of user funds behind signature semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Adds `BalanceSwapProxy`: a stateless, ownerless proxy that swaps a user's **entire then-current token balance** through the Universal Router. Sibling to `SwapProxy` (#469) — same fund-then-execute pattern (`payerIsUser=false`), but the amount is resolved at execution time instead of baked into calldata.
Primary use case: **bridge-and-swap**. Bridges deliver an unknown amount (bps-level relayer fee variance) minutes after the user signs. With this contract the user signs **once** at bridge initiation — a Permit2 `permitWitnessTransferFrom` whose witness binds the exact route — and anyone can relay the swap the moment funds land.
## Changes
- **`BalanceSwapProxy.sol`** — Three entry points sharing a common core:
  - `executeWithSig` — relayed mode via Permit2 witness signature (single-use nonce)
  - `execute` — direct mode via plain ERC20 `approve`
  - `executeWithPermit2Allowance` — direct mode via Permit2 AllowanceTransfer
  - Shared: resolve `amount = min(balanceOf(owner), cap)`, enforce `minAmount` anti-grief gate, pull directly into the router (proxy never custodies), execute route, enforce rate floor (`minPriceX36`) on recipient's output delta
- **`IBalanceSwapProxy.sol`** — Interface with `SwapIntent` struct, errors, and NatSpec
- **`DeployBalanceSwapProxy.s.sol`** — Foundry deploy script using canonical Permit2 address
- **`DeployTempo.s.sol`** — Fix missing `permissionsAdapterFactory` field added in #476
## Design Decisions
- **Route binding is cryptographic**: `routeHash = keccak256(abi.encode(commands, inputs))` folded into Permit2 witness hash — tampered routes fail signature verification; no proxy-side route check needed
- **Rate floor, not absolute minOut**: `minPriceX36` (1e36 fixed point) scales correctly with balance variance; an absolute minOut mis-scales with any estimate/actual gap
- **`minAmount` anti-grief gate**: Prevents dust-donation attacks that would consume a single-use nonce against a micro-swap that passes a rate floor
- **Graceful failure**: Reverts unwind the Permit2 pull atomically without consuming the nonce; same signature stays live for retry
## Test Plan
28 Foundry fork tests covering:
- [x] Happy paths for all 3 modes; balance-below-cap and cap-below-balance amount resolution
- [x] Adversarial relayer: tampered commands/inputs/every intent field, wrong signer/owner → Permit2 `InvalidSigner`
- [x] Replay (`InvalidNonce`), expiry (`SignatureExpired`), dust-grief blocked + same-sig success after real fill
- [x] Floor boundary exact-pass / off-by-one-revert, 6↔18 decimals asymmetry, overflow → checked-math revert
- [x] Fuzzed no-residue invariant (proxy and router hold zero after any success)
- [x] Native ETH output (`UNWRAP_WETH` route, ETH delta floor)
- [x] Reentry statelessness via a second router; gas comparison (BalanceSwapProxy 123k vs SwapProxy 101k vs direct Permit2 94k)
## Notes
- **Full audit required before mainnet deployment** — this contract gates third-party-triggered movement of user funds behind signature semantics
- Test file deliberately duplicates the EIP-712 typestring rather than reading the contract's constants — self-referential tests would verify a typo'd typestring that no real wallet could sign

</details>
<!-- claude-pr-description-end -->