### PR TITLE
fix: use canonical Sepolia v2 factory in DeploySepolia

### DIFF
--- a/script/deployParameters/DeploySepolia.s.sol
+++ b/script/deployParameters/DeploySepolia.s.sol
@@ -9,7 +9,7 @@ contract DeploySepolia is DeployUniversalRouter {
         params = RouterParameters({
             permit2: 0x000000000022D473030F116dDEE9F6B43aC78BA3,
             weth9: 0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14,
-            v2Factory: 0xF62c03E08ada871A0bEb309762E260a7a6a880E6,
+            v2Factory: 0xB7f907f7A9eBC822a80BD25E224be42Ce0A698A0,
             v3Factory: 0x0227628f3F023bb0B980b67D528571c95c6DaC1c,
             pairInitCodeHash: 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f,
             poolInitCodeHash: 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54,

--- a/script/deployParameters/DeployTempo.s.sol
+++ b/script/deployParameters/DeployTempo.s.sol
@@ -14,6 +14,7 @@ contract DeployTempo is DeployUniversalRouter {
             pairInitCodeHash: 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f,
             poolInitCodeHash: 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54,
             v4PoolManager: 0x33620f62C5b9B2086dD6b62F4A297A9f30347029,
+            permissionsAdapterFactory: address(0), // ToDo: Add permissions adapter factory
             v3NFTPositionManager: 0xb71C33f096CEabDC0229110e0d76a6382d01C633,
             v4PositionManager: 0x3Fc79444F8EACc1894775493Ff3Fa41f1e35Ce11,
             spokePool: UNSUPPORTED_PROTOCOL


### PR DESCRIPTION
## What

Changes `v2Factory` in `DeploySepolia.s.sol` from `0xF62c03E08ada871A0bEb309762E260a7a6a880E6` to `0xB7f907f7A9eBC822a80BD25E224be42Ce0A698A0`.

## Why

A UR built from main with `0xF62c03...` can't route v2 swaps against the pairs our stack quotes. `0xB7f907...` is the Sepolia v2 factory in the Uniswap/contracts deployments registry (`deployments/json/11155111.json`), and it's what the 2.1.1-tag params and existing Sepolia UR deployments use. This mismatch bit us this week: a Sepolia UR deployed from main baked in `0xF62c03...` and would have broken v2 routing for interface traffic.

## Note for reviewers

`0xF62c03...` (the address in the docs) actually has far more pairs onchain (17,379 vs 1,060), so if it's the intentional go-forward factory, the right fix is instead to update the deployments registry and routing config to match. Either way the two sources of truth disagree today and one of them should move. Flagging rather than deciding unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Fixes the Sepolia deploy script to use the canonical v2 factory address and adds a missing constructor parameter to the Tempo deploy script.
## Changes
- Update `v2Factory` in `DeploySepolia.s.sol` from `0xF62c03E08ada871A0bEb309762E260a7a6a880E6` to `0xB7f907f7A9eBC822a80BD25E224be42Ce0A698A0`, aligning with the Uniswap deployments registry (`deployments/json/11155111.json`) and existing 2.1.1-tag params
- Add missing `permissionsAdapterFactory: address(0)` to `DeployTempo.s.sol` `RouterParameters` to fix compilation after the permissioned pools refactor
## Notes
- A Sepolia UR deployed from `main` prior to this fix would bake in `0xF62c03...`, breaking v2 routing against pairs the Uniswap stack quotes
- `0xF62c03...` (the address previously in the script) actually has more pairs onchain (17,379 vs 1,060) — if it's the intended go-forward factory, the deployments registry and routing config should be updated instead

</details>
<!-- claude-pr-description-end -->