### PR TITLE
fix: bound router command input decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,21 @@ Each command is a `bytes1` containing the following 8 bits:
    ├──────┼───────────────────────────────┤
    │ 0x0d │  PERMIT2_TRANSFER_FROM_BATCH  │
    ├──────┼───────────────────────────────┤
-   │ 0x0e-│  -------                      │
+   │ 0x0e │  BALANCE_CHECK_ERC20          │
+   ├──────┼───────────────────────────────┤
+   │ 0x0f │  UNWRAP_WETH_EXACT            │
+   ├──────┼───────────────────────────────┤
+   │ 0x10 │  V4_SWAP                      │
+   ├──────┼───────────────────────────────┤
+   │ 0x11 │  V3_POSITION_MANAGER_PERMIT   │
+   ├──────┼───────────────────────────────┤
+   │ 0x12 │  V3_POSITION_MANAGER_CALL     │
+   ├──────┼───────────────────────────────┤
+   │ 0x13 │  V4_INITIALIZE_POOL           │
+   ├──────┼───────────────────────────────┤
+   │ 0x14 │  V4_POSITION_MANAGER_CALL     │
+   ├──────┼───────────────────────────────┤
+   │ 0x15-│  -------                      │
    │ 0x20 │                               │
    ├──────┼───────────────────────────────┤
    │ 0x21 │  EXECUTE_SUB_PLAN             │
@@ -95,6 +109,8 @@ Each command is a `bytes1` containing the following 8 bits:
 ```
 
 Note that some of the commands in the middle of the series are unused. These gaps allowed us to create gas-efficiencies when selecting which command to execute.
+
+`UNWRAP_WETH_EXACT` takes `(recipient, amount)` and unwraps an exact amount of the contract's WETH, reverting if the balance is insufficient.
 
 #### How the input bytes are structures
 

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -172,8 +172,6 @@ abstract contract Dispatcher is
                             portion := calldataload(add(inputs.offset, 0x40))
                         }
                         Payments.payPortionFullPrecision(token, map(recipient), portion);
-                    } else {
-                        revert InvalidCommandType(command);
                     }
                 } else {
                     // 0x08 <= command < 0x10
@@ -271,9 +269,16 @@ abstract contract Dispatcher is
                         }
                         success = (ERC20(token).balanceOf(owner) >= minBalance);
                         if (!success) output = abi.encodePacked(BalanceTooLow.selector);
-                    } else {
-                        // placeholder area for command 0x0f
-                        revert InvalidCommandType(command);
+                    } else if (command == Commands.UNWRAP_WETH_EXACT) {
+                        checkInputLength(inputs, 0x40);
+                        // equivalent: abi.decode(inputs, (address, uint256))
+                        address recipient;
+                        uint256 amount;
+                        assembly {
+                            recipient := calldataload(inputs.offset)
+                            amount := calldataload(add(inputs.offset, 0x20))
+                        }
+                        Payments.unwrapWETH9Exact(map(recipient), amount);
                     }
                 }
             } else {

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -131,7 +131,7 @@ abstract contract Dispatcher is
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
-                        uint160 amountMin;
+                        uint256 amountMin;
                         assembly {
                             token := calldataload(inputs.offset)
                             recipient := calldataload(add(inputs.offset, 0x20))
@@ -352,14 +352,15 @@ abstract contract Dispatcher is
         pure
         returns (IAllowanceTransfer.PermitBatch calldata permitBatch)
     {
-        checkInputLength(input, 0x40);
+        // PermitBatch has a three-word head: details offset, spender, and signature deadline.
+        checkInputLength(input, 0x60);
 
         assembly ('memory-safe') {
             let inputLength := input.length
             let permitBatchOffset := calldataload(input.offset)
 
-            // PermitBatch has a three-word head: details offset, spender, and signature deadline.
-            if or(lt(inputLength, 0x60), gt(permitBatchOffset, sub(inputLength, 0x60))) {
+            // The PermitBatch head must be contained in the input.
+            if gt(permitBatchOffset, sub(inputLength, 0x60)) {
                 mstore(0, 0x3b99b53d) // SliceOutOfBounds()
                 revert(0x1c, 0x04)
             }

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -65,6 +65,7 @@ abstract contract Dispatcher is
                 // 0x00 <= command < 0x08
                 if (command < Commands.V2_SWAP_EXACT_IN) {
                     if (command == Commands.V3_SWAP_EXACT_IN) {
+                        checkInputLength(inputs, 0xc0);
                         // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool, uint256[]))
                         address recipient;
                         uint256 amountIn;
@@ -82,6 +83,7 @@ abstract contract Dispatcher is
                         address payer = payerIsUser ? msgSender() : address(this);
                         v3SwapExactInput(map(recipient), amountIn, amountOutMin, path, payer, minHopPriceX36);
                     } else if (command == Commands.V3_SWAP_EXACT_OUT) {
+                        checkInputLength(inputs, 0xc0);
                         // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool, uint256[]))
                         address recipient;
                         uint256 amountOut;
@@ -99,6 +101,7 @@ abstract contract Dispatcher is
                         address payer = payerIsUser ? msgSender() : address(this);
                         v3SwapExactOutput(map(recipient), amountOut, amountInMax, path, payer, minHopPriceX36);
                     } else if (command == Commands.PERMIT2_TRANSFER_FROM) {
+                        checkInputLength(inputs, 0x60);
                         // equivalent: abi.decode(inputs, (address, address, uint160))
                         address token;
                         address recipient;
@@ -110,12 +113,7 @@ abstract contract Dispatcher is
                         }
                         permit2TransferFrom(token, msgSender(), map(recipient), amount);
                     } else if (command == Commands.PERMIT2_PERMIT_BATCH) {
-                        IAllowanceTransfer.PermitBatch calldata permitBatch;
-                        assembly {
-                            // this is a variable length struct, so calldataload(inputs.offset) contains the
-                            // offset from inputs.offset at which the struct begins
-                            permitBatch := add(inputs.offset, calldataload(inputs.offset))
-                        }
+                        IAllowanceTransfer.PermitBatch calldata permitBatch = decodePermitBatch(inputs);
                         bytes calldata data = inputs.toBytes(1);
                         (success, output) = address(PERMIT2)
                             .call(
@@ -127,6 +125,7 @@ abstract contract Dispatcher is
                                 )
                             );
                     } else if (command == Commands.SWEEP) {
+                        checkInputLength(inputs, 0x60);
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
@@ -138,6 +137,7 @@ abstract contract Dispatcher is
                         }
                         Payments.sweep(token, map(recipient), amountMin);
                     } else if (command == Commands.TRANSFER) {
+                        checkInputLength(inputs, 0x60);
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
@@ -149,6 +149,7 @@ abstract contract Dispatcher is
                         }
                         Payments.pay(token, map(recipient), value);
                     } else if (command == Commands.PAY_PORTION) {
+                        checkInputLength(inputs, 0x60);
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
@@ -160,6 +161,7 @@ abstract contract Dispatcher is
                         }
                         Payments.payPortion(token, map(recipient), bips);
                     } else if (command == Commands.PAY_PORTION_FULL_PRECISION) {
+                        checkInputLength(inputs, 0x60);
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
@@ -176,6 +178,7 @@ abstract contract Dispatcher is
                 } else {
                     // 0x08 <= command < 0x10
                     if (command == Commands.V2_SWAP_EXACT_IN) {
+                        checkInputLength(inputs, 0xc0);
                         // equivalent: abi.decode(inputs, (address, uint256, uint256, address[], bool, uint256[]))
                         address recipient;
                         uint256 amountIn;
@@ -193,6 +196,7 @@ abstract contract Dispatcher is
                         address payer = payerIsUser ? msgSender() : address(this);
                         v2SwapExactInput(map(recipient), amountIn, amountOutMin, path, payer, minHopPriceX36);
                     } else if (command == Commands.V2_SWAP_EXACT_OUT) {
+                        checkInputLength(inputs, 0xc0);
                         // equivalent: abi.decode(inputs, (address, uint256, uint256, address[], bool, uint256[]))
                         address recipient;
                         uint256 amountOut;
@@ -210,6 +214,7 @@ abstract contract Dispatcher is
                         address payer = payerIsUser ? msgSender() : address(this);
                         v2SwapExactOutput(map(recipient), amountOut, amountInMax, path, payer, minHopPriceX36);
                     } else if (command == Commands.PERMIT2_PERMIT) {
+                        checkInputLength(inputs, 0xe0);
                         // equivalent: abi.decode(inputs, (IAllowanceTransfer.PermitSingle, bytes))
                         IAllowanceTransfer.PermitSingle calldata permitSingle;
                         assembly {
@@ -226,6 +231,7 @@ abstract contract Dispatcher is
                                 )
                             );
                     } else if (command == Commands.WRAP_ETH) {
+                        checkInputLength(inputs, 0x40);
                         // equivalent: abi.decode(inputs, (address, uint256))
                         address recipient;
                         uint256 amount;
@@ -235,6 +241,7 @@ abstract contract Dispatcher is
                         }
                         Payments.wrapETH(map(recipient), amount);
                     } else if (command == Commands.UNWRAP_WETH) {
+                        checkInputLength(inputs, 0x40);
                         // equivalent: abi.decode(inputs, (address, uint256))
                         address recipient;
                         uint256 amountMin;
@@ -245,13 +252,14 @@ abstract contract Dispatcher is
                         Payments.unwrapWETH9(map(recipient), amountMin);
                     } else if (command == Commands.PERMIT2_TRANSFER_FROM_BATCH) {
                         IAllowanceTransfer.AllowanceTransferDetails[] calldata batchDetails;
-                        (uint256 length, uint256 offset) = inputs.toLengthOffset(0);
+                        (uint256 length, uint256 offset) = inputs.toLengthOffset(0, 0x80);
                         assembly {
                             batchDetails.length := length
                             batchDetails.offset := offset
                         }
                         permit2TransferFrom(batchDetails, msgSender());
                     } else if (command == Commands.BALANCE_CHECK_ERC20) {
+                        checkInputLength(inputs, 0x60);
                         // equivalent: abi.decode(inputs, (address, address, uint256))
                         address owner;
                         address token;
@@ -281,6 +289,7 @@ abstract contract Dispatcher is
                     _checkV3PositionManagerCall(inputs, msgSender());
                     (success, output) = address(V3_POSITION_MANAGER).call(inputs);
                 } else if (command == Commands.V4_INITIALIZE_POOL) {
+                    checkInputLength(inputs, 0xc0);
                     PoolKey calldata poolKey;
                     uint160 sqrtPriceX96;
                     assembly {
@@ -314,6 +323,54 @@ abstract contract Dispatcher is
                 // placeholder area for commands 0x41-0x5f
                 revert InvalidCommandType(command);
             }
+        }
+    }
+
+    /// @dev Reverts if an input cannot contain the complete static ABI head consumed by a command.
+    function checkInputLength(bytes calldata input, uint256 minimumLength) private pure {
+        if (input.length < minimumLength) revert CalldataDecoder.SliceOutOfBounds();
+    }
+
+    /// @dev Decodes a Permit2 batch after validating its dynamic details array against the input bounds.
+    function decodePermitBatch(bytes calldata input)
+        private
+        pure
+        returns (IAllowanceTransfer.PermitBatch calldata permitBatch)
+    {
+        checkInputLength(input, 0x40);
+
+        assembly ('memory-safe') {
+            let inputLength := input.length
+            let permitBatchOffset := calldataload(input.offset)
+
+            // PermitBatch has a three-word head: details offset, spender, and signature deadline.
+            if or(lt(inputLength, 0x60), gt(permitBatchOffset, sub(inputLength, 0x60))) {
+                mstore(0, 0x3b99b53d) // SliceOutOfBounds()
+                revert(0x1c, 0x04)
+            }
+
+            let permitBatchPointer := add(input.offset, permitBatchOffset)
+            let detailsOffset := calldataload(permitBatchPointer)
+            let permitBatchLength := sub(inputLength, permitBatchOffset)
+
+            // The PermitDetails array length word must be contained in the PermitBatch slice.
+            if gt(detailsOffset, sub(permitBatchLength, 0x20)) {
+                mstore(0, 0x3b99b53d) // SliceOutOfBounds()
+                revert(0x1c, 0x04)
+            }
+
+            let detailsLengthPointer := add(permitBatchPointer, detailsOffset)
+            let detailsLength := calldataload(detailsLengthPointer)
+            let detailsDataOffset := add(detailsOffset, 0x20)
+            let remainingLength := sub(permitBatchLength, detailsDataOffset)
+
+            // Each PermitDetails element occupies four words.
+            if gt(detailsLength, div(remainingLength, 0x80)) {
+                mstore(0, 0x3b99b53d) // SliceOutOfBounds()
+                revert(0x1c, 0x04)
+            }
+
+            permitBatch := permitBatchPointer
         }
     }
 

--- a/contracts/interfaces/IUniversalRouter.sol
+++ b/contracts/interfaces/IUniversalRouter.sol
@@ -70,8 +70,8 @@ interface IUniversalRouter {
     /// @return intent The intent value from the signed execution, or bytes32(0) if not in a signed execution
     /// @return data The data value from the signed execution, or bytes32(0) if not in a signed execution
     /// @dev This reads from transient storage which is only set during executeSigned().
-    /// @dev When consuming this context from a hook, the hook MUST verify that msg.sender is the
-    /// UniversalRouter contract. Otherwise, a malicious contract in the execution chain could abuse the
-    /// legitimate signed context by calling other contracts with it, causing unintended side effects.
+    /// @dev When consuming this context from a V4 hook, the hook MUST verify that msg.sender is the PoolManager
+    /// and that the hook's sender parameter is the UniversalRouter. Otherwise, a malicious contract in the
+    /// execution chain could abuse the legitimate signed context by initiating its own swap.
     function signedRouteContext() external view returns (address signer, bytes32 intent, bytes32 data);
 }

--- a/contracts/libraries/Commands.sol
+++ b/contracts/libraries/Commands.sol
@@ -29,7 +29,7 @@ library Commands {
     uint256 constant UNWRAP_WETH = 0x0c;
     uint256 constant PERMIT2_TRANSFER_FROM_BATCH = 0x0d;
     uint256 constant BALANCE_CHECK_ERC20 = 0x0e;
-    // COMMAND_PLACEHOLDER = 0x0f;
+    uint256 constant UNWRAP_WETH_EXACT = 0x0f;
 
     // Command Types where 0x10<=value<=0x20, executed in the third nested-if block
     uint256 constant V4_SWAP = 0x10;

--- a/contracts/modules/Payments.sol
+++ b/contracts/modules/Payments.sol
@@ -117,4 +117,17 @@ abstract contract Payments is PaymentsImmutables {
             }
         }
     }
+
+    /// @notice Unwraps an exact amount of the contract's WETH into ETH
+    /// @param recipient The recipient of the ETH
+    /// @param amount The exact amount of WETH to unwrap
+    function unwrapWETH9Exact(address recipient, uint256 amount) internal {
+        if (WETH9.balanceOf(address(this)) < amount) revert InsufficientETH();
+        if (amount > 0) {
+            WETH9.withdraw(amount);
+            if (recipient != address(this)) {
+                recipient.safeTransferETH(amount);
+            }
+        }
+    }
 }

--- a/contracts/modules/V3ToV4Migrator.sol
+++ b/contracts/modules/V3ToV4Migrator.sol
@@ -32,6 +32,8 @@ abstract contract V3ToV4Migrator is MigratorImmutables {
 
     /// @dev check that a call is to the ERC721 permit function
     function _checkV3PermitCall(bytes calldata inputs) internal pure {
+        if (inputs.length < 0x04) revert CalldataDecoder.SliceOutOfBounds();
+
         bytes4 selector;
         assembly {
             selector := calldataload(inputs.offset)
@@ -44,6 +46,8 @@ abstract contract V3ToV4Migrator is MigratorImmutables {
 
     /// @dev check that the v3 position manager call is a safe call
     function _checkV3PositionManagerCall(bytes calldata inputs, address caller) internal view {
+        if (inputs.length < 0x24) revert CalldataDecoder.SliceOutOfBounds();
+
         bytes4 selector;
         assembly {
             selector := calldataload(inputs.offset)
@@ -72,6 +76,8 @@ abstract contract V3ToV4Migrator is MigratorImmutables {
     /// this is because, if a user could be tricked into approving the UniversalRouter for
     /// their position, an attacker could take their fees, or drain their entire position
     function _checkV4PositionManagerCall(bytes calldata inputs) internal view {
+        if (inputs.length < 0x04) revert CalldataDecoder.SliceOutOfBounds();
+
         bytes4 selector;
         assembly {
             selector := calldataload(inputs.offset)

--- a/contracts/modules/uniswap/v3/BytesLib.sol
+++ b/contracts/modules/uniswap/v3/BytesLib.sol
@@ -50,14 +50,43 @@ library BytesLib {
         pure
         returns (uint256 length, uint256 offset)
     {
-        assembly {
+        return toLengthOffset(_bytes, _arg, 0x20);
+    }
+
+    /// @notice Decode the `_arg`-th element in `_bytes` as a dynamic array with fixed-size elements.
+    /// @param _bytes The input bytes string to slice
+    /// @param _arg The index of the argument to extract
+    /// @param _elementSize The ABI-encoded size of each array element
+    /// @return length Length of the array
+    /// @return offset Pointer to the data part of the array
+    function toLengthOffset(bytes calldata _bytes, uint256 _arg, uint256 _elementSize)
+        internal
+        pure
+        returns (uint256 length, uint256 offset)
+    {
+        assembly ('memory-safe') {
             // The offset of the `_arg`-th element is `32 * arg`, which stores the offset of the length pointer.
             // shl(5, x) is equivalent to mul(32, x)
-            let lengthPtr := add(_bytes.offset, calldataload(add(_bytes.offset, shl(5, _arg))))
+            let headOffset := shl(5, _arg)
+            if or(iszero(_elementSize), gt(add(headOffset, 0x20), _bytes.length)) {
+                mstore(0, 0x3b99b53d) // SliceOutOfBounds()
+                revert(0x1c, 0x04)
+            }
+
+            let relativeLengthPtr := calldataload(add(_bytes.offset, headOffset))
+            if gt(relativeLengthPtr, sub(_bytes.length, 0x20)) {
+                mstore(0, 0x3b99b53d) // SliceOutOfBounds()
+                revert(0x1c, 0x04)
+            }
+
+            let lengthPtr := add(_bytes.offset, relativeLengthPtr)
             length := calldataload(lengthPtr)
             offset := add(lengthPtr, 0x20)
-            let relativeOffset := sub(offset, _bytes.offset)
-            if lt(_bytes.length, add(shl(5, length), relativeOffset)) {
+            let relativeOffset := add(relativeLengthPtr, 0x20)
+            let remainingLength := sub(_bytes.length, relativeOffset)
+
+            // Comparing before multiplication prevents length * elementSize from overflowing.
+            if gt(length, div(remainingLength, _elementSize)) {
                 mstore(0, 0x3b99b53d) // SliceOutOfBounds()
                 revert(0x1c, 0x04)
             }

--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "22093"
+  "UniversalRouter bytecode size": "22405"
 }

--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "22577"
+  "UniversalRouter bytecode size": "22574"
 }

--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "22177"
+  "UniversalRouter bytecode size": "22093"
 }

--- a/test/foundry-tests/RouteSigner.t.sol
+++ b/test/foundry-tests/RouteSigner.t.sol
@@ -9,6 +9,7 @@ import {Lock} from '../../contracts/base/Lock.sol';
 import {Constants} from '../../contracts/libraries/Constants.sol';
 import {Commands} from '../../contracts/libraries/Commands.sol';
 import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {BytesLib} from '../../contracts/modules/uniswap/v3/BytesLib.sol';
 
 contract ContextCapture {
     UniversalRouter public router;
@@ -130,6 +131,92 @@ contract RouteSignerTest is Test {
         // Sign
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPrivateKey, digest);
         signature = abi.encodePacked(r, s, v);
+    }
+
+    function encodeExecuteSignedWithSmuggledTransfer(
+        bytes memory commands,
+        bytes32 intent,
+        bytes32 data,
+        bytes32 nonce,
+        bytes memory signature,
+        uint256 deadline,
+        address token,
+        address recipient,
+        uint256 value
+    ) internal pure returns (bytes memory callData) {
+        bytes[] memory executionInputs = new bytes[](1);
+        executionInputs[0] = abi.encode(token, recipient, value);
+
+        callData = abi.encodeWithSelector(
+            IUniversalRouter.executeSigned.selector,
+            commands,
+            executionInputs,
+            intent,
+            data,
+            true,
+            nonce,
+            signature,
+            deadline
+        );
+
+        uint256 argsStart;
+        assembly {
+            argsStart := add(add(callData, 0x20), 0x04)
+        }
+
+        uint256 inputsOffset;
+        assembly {
+            inputsOffset := mload(add(argsStart, 0x20))
+        }
+        uint256 inputsStart = argsStart + inputsOffset;
+
+        uint256 firstInputOffset;
+        assembly {
+            firstInputOffset := mload(add(inputsStart, 0x20))
+        }
+        uint256 firstInputLengthPointer = inputsStart + 0x20 + firstInputOffset;
+
+        assembly {
+            mstore(firstInputLengthPointer, 0)
+        }
+    }
+
+    function testExecuteSignedRejectsSmuggledTransferInput() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.TRANSFER)));
+        bytes[] memory signedInputs = new bytes[](1);
+        signedInputs[0] = hex'';
+
+        bytes32 intent = keccak256('zero-length-smuggled-input-intent');
+        bytes32 data = keccak256('zero-length-smuggled-input-data');
+        bytes32 nonce = keccak256('zero-length-smuggled-input-nonce');
+        uint256 deadline = block.timestamp + 1000;
+
+        bytes memory signature = signExecution(commands, signedInputs, intent, data, address(this), nonce, deadline);
+        bytes memory callData = encodeExecuteSignedWithSmuggledTransfer(
+            commands, intent, data, nonce, signature, deadline, Constants.ETH, address(capturer), AMOUNT
+        );
+
+        (bool success, bytes memory returnData) = address(router).call{value: AMOUNT}(callData);
+
+        assertFalse(success, 'smuggled transfer should revert');
+        assertEq(
+            keccak256(returnData),
+            keccak256(abi.encodeWithSelector(BytesLib.SliceOutOfBounds.selector)),
+            'unexpected revert'
+        );
+        assertEq(address(capturer).balance, 0, 'smuggled recipient should not receive ETH');
+        assertFalse(router.noncesUsed(signer, nonce), 'reverted route should not consume nonce');
+    }
+
+    function testFuzzTransferRejectsShortInput(uint256 inputLength) public {
+        inputLength = bound(inputLength, 0, 0x5f);
+
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.TRANSFER)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = new bytes(inputLength);
+
+        vm.expectRevert(BytesLib.SliceOutOfBounds.selector);
+        router.execute(commands, inputs);
     }
 
     function testExecuteSigned() public {

--- a/test/foundry-tests/UniversalRouter.t.sol
+++ b/test/foundry-tests/UniversalRouter.t.sol
@@ -57,8 +57,8 @@ contract UniversalRouterTest is Test {
     }
 
     function testRejectsShortStaticCommandInputs() public {
-        uint256[] memory commandTypes = new uint256[](14);
-        uint256[] memory minimumLengths = new uint256[](14);
+        uint256[] memory commandTypes = new uint256[](15);
+        uint256[] memory minimumLengths = new uint256[](15);
 
         commandTypes[0] = Commands.V3_SWAP_EXACT_IN;
         commandTypes[1] = Commands.V3_SWAP_EXACT_OUT;
@@ -73,7 +73,8 @@ contract UniversalRouterTest is Test {
         commandTypes[10] = Commands.WRAP_ETH;
         commandTypes[11] = Commands.UNWRAP_WETH;
         commandTypes[12] = Commands.BALANCE_CHECK_ERC20;
-        commandTypes[13] = Commands.V4_INITIALIZE_POOL;
+        commandTypes[13] = Commands.UNWRAP_WETH_EXACT;
+        commandTypes[14] = Commands.V4_INITIALIZE_POOL;
 
         minimumLengths[0] = 0xc0;
         minimumLengths[1] = 0xc0;
@@ -88,7 +89,8 @@ contract UniversalRouterTest is Test {
         minimumLengths[10] = 0x40;
         minimumLengths[11] = 0x40;
         minimumLengths[12] = 0x60;
-        minimumLengths[13] = 0xc0;
+        minimumLengths[13] = 0x40;
+        minimumLengths[14] = 0xc0;
 
         bytes[] memory inputs = new bytes[](1);
         for (uint256 i; i < commandTypes.length; ++i) {

--- a/test/foundry-tests/UniversalRouter.t.sol
+++ b/test/foundry-tests/UniversalRouter.t.sol
@@ -9,6 +9,7 @@ import {Commands} from '../../contracts/libraries/Commands.sol';
 import {MockERC20} from './mock/MockERC20.sol';
 import {ExampleModule} from '../../contracts/test/ExampleModule.sol';
 import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {BytesLib} from '../../contracts/modules/uniswap/v3/BytesLib.sol';
 import {ERC20} from 'solmate/src/tokens/ERC20.sol';
 import 'permit2/src/interfaces/IAllowanceTransfer.sol';
 import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
@@ -53,6 +54,104 @@ contract UniversalRouterTest is Test {
             bytecodeSize := extcodesize(theRouter)
         }
         emit log_uint(bytecodeSize);
+    }
+
+    function testRejectsShortStaticCommandInputs() public {
+        uint256[] memory commandTypes = new uint256[](14);
+        uint256[] memory minimumLengths = new uint256[](14);
+
+        commandTypes[0] = Commands.V3_SWAP_EXACT_IN;
+        commandTypes[1] = Commands.V3_SWAP_EXACT_OUT;
+        commandTypes[2] = Commands.PERMIT2_TRANSFER_FROM;
+        commandTypes[3] = Commands.SWEEP;
+        commandTypes[4] = Commands.TRANSFER;
+        commandTypes[5] = Commands.PAY_PORTION;
+        commandTypes[6] = Commands.PAY_PORTION_FULL_PRECISION;
+        commandTypes[7] = Commands.V2_SWAP_EXACT_IN;
+        commandTypes[8] = Commands.V2_SWAP_EXACT_OUT;
+        commandTypes[9] = Commands.PERMIT2_PERMIT;
+        commandTypes[10] = Commands.WRAP_ETH;
+        commandTypes[11] = Commands.UNWRAP_WETH;
+        commandTypes[12] = Commands.BALANCE_CHECK_ERC20;
+        commandTypes[13] = Commands.V4_INITIALIZE_POOL;
+
+        minimumLengths[0] = 0xc0;
+        minimumLengths[1] = 0xc0;
+        minimumLengths[2] = 0x60;
+        minimumLengths[3] = 0x60;
+        minimumLengths[4] = 0x60;
+        minimumLengths[5] = 0x60;
+        minimumLengths[6] = 0x60;
+        minimumLengths[7] = 0xc0;
+        minimumLengths[8] = 0xc0;
+        minimumLengths[9] = 0xe0;
+        minimumLengths[10] = 0x40;
+        minimumLengths[11] = 0x40;
+        minimumLengths[12] = 0x60;
+        minimumLengths[13] = 0xc0;
+
+        bytes[] memory inputs = new bytes[](1);
+        for (uint256 i; i < commandTypes.length; ++i) {
+            bytes memory commands = abi.encodePacked(bytes1(uint8(commandTypes[i])));
+            inputs[0] = new bytes(minimumLengths[i] - 1);
+
+            vm.expectRevert(BytesLib.SliceOutOfBounds.selector);
+            router.execute(commands, inputs);
+        }
+    }
+
+    function testRejectsShortDynamicCommandInputs() public {
+        uint256[] memory commandTypes = new uint256[](5);
+        commandTypes[0] = Commands.PERMIT2_PERMIT_BATCH;
+        commandTypes[1] = Commands.PERMIT2_TRANSFER_FROM_BATCH;
+        commandTypes[2] = Commands.V3_POSITION_MANAGER_PERMIT;
+        commandTypes[3] = Commands.V3_POSITION_MANAGER_CALL;
+        commandTypes[4] = Commands.V4_POSITION_MANAGER_CALL;
+
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = hex'';
+
+        for (uint256 i; i < commandTypes.length; ++i) {
+            bytes memory commands = abi.encodePacked(bytes1(uint8(commandTypes[i])));
+
+            vm.expectRevert(BytesLib.SliceOutOfBounds.selector);
+            router.execute(commands, inputs);
+        }
+    }
+
+    function testPermit2PermitBatchDecodesBoundedDetails() public {
+        IAllowanceTransfer.PermitDetails[] memory details = new IAllowanceTransfer.PermitDetails[](1);
+        details[0] = IAllowanceTransfer.PermitDetails({
+            token: address(erc20), amount: 1 ether, expiration: type(uint48).max, nonce: 0
+        });
+        IAllowanceTransfer.PermitBatch memory permitBatch =
+            IAllowanceTransfer.PermitBatch({details: details, spender: address(router), sigDeadline: block.timestamp});
+
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.PERMIT2_PERMIT_BATCH)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(permitBatch, hex'');
+
+        router.execute(commands, inputs);
+    }
+
+    function testPermit2PermitBatchRejectsTruncatedDetails() public {
+        IAllowanceTransfer.PermitDetails[] memory details = new IAllowanceTransfer.PermitDetails[](1);
+        details[0] = IAllowanceTransfer.PermitDetails({
+            token: address(erc20), amount: 1 ether, expiration: type(uint48).max, nonce: 0
+        });
+        IAllowanceTransfer.PermitBatch memory permitBatch =
+            IAllowanceTransfer.PermitBatch({details: details, spender: address(router), sigDeadline: block.timestamp});
+
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.PERMIT2_PERMIT_BATCH)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(permitBatch, hex'');
+
+        assembly {
+            mstore(mload(add(inputs, 0x20)), 0x120)
+        }
+
+        vm.expectRevert(BytesLib.SliceOutOfBounds.selector);
+        router.execute(commands, inputs);
     }
 
     function testSweepToken() public {

--- a/test/foundry-tests/UniversalRouter.t.sol
+++ b/test/foundry-tests/UniversalRouter.t.sol
@@ -181,6 +181,44 @@ contract UniversalRouterTest is Test {
         router.execute(commands, inputs);
     }
 
+    /// @dev SWEEP declares a uint256 amountMinimum. A narrower decode would enforce only the
+    /// low 160 bits, silently reducing minima at or above 2**160 modulo 2**160.
+    function testSweepTokenEnforcesFullWidthMinimum() public {
+        uint256[] memory minimums = new uint256[](4);
+        minimums[0] = uint256(type(uint160).max) + 1; // 2**160, truncates to 0
+        minimums[1] = uint256(type(uint160).max) + 1 + AMOUNT - 1; // truncates to AMOUNT - 1
+        minimums[2] = uint256(type(uint160).max) + 1 + AMOUNT; // truncates to AMOUNT
+        minimums[3] = type(uint256).max;
+
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.SWEEP)));
+
+        for (uint256 i = 0; i < minimums.length; i++) {
+            uint256 state = vm.snapshotState();
+
+            bytes[] memory inputs = new bytes[](1);
+            inputs[0] = abi.encode(address(erc20), RECIPIENT, minimums[i]);
+            erc20.mint(address(router), AMOUNT);
+
+            vm.expectRevert(Payments.InsufficientToken.selector);
+            router.execute(commands, inputs);
+
+            assertEq(erc20.balanceOf(RECIPIENT), 0);
+            assertTrue(vm.revertToState(state));
+        }
+    }
+
+    function testSweepTokenAtUint160MaxMinimum() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.SWEEP)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(address(erc20), RECIPIENT, uint256(type(uint160).max));
+
+        erc20.mint(address(router), type(uint160).max);
+
+        router.execute(commands, inputs);
+
+        assertEq(erc20.balanceOf(RECIPIENT), type(uint160).max);
+    }
+
     function testSweepETH() public {
         bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.SWEEP)));
         bytes[] memory inputs = new bytes[](1);

--- a/test/integration-tests/UniversalRouter.test.ts
+++ b/test/integration-tests/UniversalRouter.test.ts
@@ -103,6 +103,78 @@ describe('UniversalRouter', () => {
         .withArgs(parseInt(invalidCommand))
     })
 
+    describe('UNWRAP_WETH_EXACT', () => {
+      it('unwraps an exact partial amount and leaves the remainder as WETH', async () => {
+        const total = expandTo18DecimalsBN(3)
+        const amount = expandTo18DecimalsBN(1)
+        await wethContract.transfer(router.address, total)
+
+        planner.addCommand(CommandType.UNWRAP_WETH_EXACT, [ADDRESS_THIS, amount])
+        const { commands, inputs } = planner
+
+        const ethBalanceBefore = await ethers.provider.getBalance(router.address)
+        await router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE)
+
+        expect(await wethContract.balanceOf(router.address)).to.eq(total.sub(amount))
+        expect(await ethers.provider.getBalance(router.address)).to.eq(ethBalanceBefore.add(amount))
+      })
+
+      it('sends ETH to an external recipient', async () => {
+        const total = expandTo18DecimalsBN(3)
+        const amount = expandTo18DecimalsBN(1)
+        const recipient = (await ethers.getSigners())[1]
+        await wethContract.transfer(router.address, total)
+
+        planner.addCommand(CommandType.UNWRAP_WETH_EXACT, [recipient.address, amount])
+        const { commands, inputs } = planner
+
+        const ethBalanceBefore = await ethers.provider.getBalance(recipient.address)
+        await router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE)
+
+        expect(await wethContract.balanceOf(router.address)).to.eq(total.sub(amount))
+        expect(await ethers.provider.getBalance(recipient.address)).to.eq(ethBalanceBefore.add(amount))
+      })
+
+      it('unwraps the full balance when amount equals the WETH balance', async () => {
+        const total = expandTo18DecimalsBN(3)
+        await wethContract.transfer(router.address, total)
+
+        planner.addCommand(CommandType.UNWRAP_WETH_EXACT, [ADDRESS_THIS, total])
+        const { commands, inputs } = planner
+
+        const ethBalanceBefore = await ethers.provider.getBalance(router.address)
+        await router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE)
+
+        expect(await wethContract.balanceOf(router.address)).to.eq(0)
+        expect(await ethers.provider.getBalance(router.address)).to.eq(ethBalanceBefore.add(total))
+      })
+
+      it('does nothing when amount is zero', async () => {
+        const total = expandTo18DecimalsBN(3)
+        await wethContract.transfer(router.address, total)
+
+        planner.addCommand(CommandType.UNWRAP_WETH_EXACT, [ADDRESS_THIS, 0])
+        const { commands, inputs } = planner
+
+        const ethBalanceBefore = await ethers.provider.getBalance(router.address)
+        await router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE)
+
+        expect(await wethContract.balanceOf(router.address)).to.eq(total)
+        expect(await ethers.provider.getBalance(router.address)).to.eq(ethBalanceBefore)
+      })
+
+      it('reverts when the amount exceeds the router WETH balance', async () => {
+        await wethContract.transfer(router.address, expandTo18DecimalsBN(3))
+
+        planner.addCommand(CommandType.UNWRAP_WETH_EXACT, [ADDRESS_THIS, expandTo18DecimalsBN(4)])
+        const { commands, inputs } = planner
+
+        await expect(
+          router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE)
+        ).to.be.revertedWithCustomError(router, 'InsufficientETH')
+      })
+    })
+
     it('reverts if paying a portion over 100% of contract balance', async () => {
       await daiContract.transfer(router.address, expandTo18DecimalsBN(1))
       planner.addCommand(CommandType.PAY_PORTION, [WETH.address, alice.address, 11_000])

--- a/test/integration-tests/gas-tests/Payments.gas.test.ts
+++ b/test/integration-tests/gas-tests/Payments.gas.test.ts
@@ -61,6 +61,17 @@ describe('Payments Gas Tests', () => {
       await snapshotGasCost(router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE))
     })
 
+    it('gas: UNWRAP_WETH_EXACT partial amount', async () => {
+      const total: BigNumber = expandTo18DecimalsBN(3)
+      const amount: BigNumber = expandTo18DecimalsBN(1)
+      await wethContract.transfer(router.address, total)
+
+      planner.addCommand(CommandType.UNWRAP_WETH_EXACT, [alice.address, amount])
+      const { commands, inputs } = planner
+
+      await snapshotGasCost(router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE))
+    })
+
     it('gas: TRANSFER with ETH', async () => {
       // seed router with WETH and unwrap it into the router
       const amount: BigNumber = expandTo18DecimalsBN(3)

--- a/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Check Ownership Gas gas: balance check ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 37904,
+  "gasUsed": 38007,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -35,6 +35,13 @@ Object {
 }
 `;
 
+exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_EXACT partial amount 1`] = `
+Object {
+  "calldataByteLength": 324,
+  "gasUsed": 49898,
+}
+`;
+
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 37345,
+  "gasUsed": 37348,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 66139,
+  "gasUsed": 66142,
 }
 `;
 
@@ -45,7 +45,7 @@ Object {
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 51491,
+  "gasUsed": 51494,
 }
 `;
 

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -3,48 +3,48 @@
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 37301,
+  "gasUsed": 37345,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 66081,
+  "gasUsed": 66139,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 36205,
+  "gasUsed": 36360,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ETH 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 31764,
+  "gasUsed": 31922,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 44998,
+  "gasUsed": 44972,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 51432,
+  "gasUsed": 51491,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: WRAP_ETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 53675,
+  "gasUsed": 53748,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,105 +3,105 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, both fail but the transaction succeeds 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 279169,
+  "gasUsed": 277705,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, neither fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 254827,
+  "gasUsed": 253398,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, second sub plan fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 254827,
+  "gasUsed": 253398,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, the first fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 279169,
+  "gasUsed": 277705,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V2, then V3 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 195036,
+  "gasUsed": 193723,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V3, then V2 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 182301,
+  "gasUsed": 181260,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, different input tokens, each two hop, with batch permit 1`] = `
 Object {
   "calldataByteLength": 1668,
-  "gasUsed": 303496,
+  "gasUsed": 301758,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit 1`] = `
 Object {
   "calldataByteLength": 1348,
-  "gasUsed": 313888,
+  "gasUsed": 312299,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit transfer from batch 1`] = `
 Object {
   "calldataByteLength": 1412,
-  "gasUsed": 315213,
+  "gasUsed": 313394,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, without explicit permit 1`] = `
 Object {
   "calldataByteLength": 1028,
-  "gasUsed": 310470,
+  "gasUsed": 308591,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 182486,
+  "gasUsed": 181336,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 182261,
+  "gasUsed": 181111,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, exactOut, one hop 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 197587,
+  "gasUsed": 196771,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 190490,
+  "gasUsed": 189270,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1252,
-  "gasUsed": 197179,
+  "gasUsed": 196085,
 }
 `;
 
@@ -143,98 +143,98 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn trade, where an output fee is taken 1`] = `
 Object {
   "calldataByteLength": 900,
-  "gasUsed": 129238,
+  "gasUsed": 128604,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 109217,
+  "gasUsed": 108605,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 245370,
+  "gasUsed": 244183,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops, no deadline 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 245112,
+  "gasUsed": 243925,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 177333,
+  "gasUsed": 176431,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops, MSG_SENDER flag 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 177333,
+  "gasUsed": 176431,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 108370,
+  "gasUsed": 108157,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 250378,
+  "gasUsed": 249492,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 179439,
+  "gasUsed": 178895,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 125737,
+  "gasUsed": 125019,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 868,
-  "gasUsed": 130284,
+  "gasUsed": 129893,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, with ETH fee 1`] = `
 Object {
   "calldataByteLength": 1028,
-  "gasUsed": 138162,
+  "gasUsed": 137917,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 109045,
+  "gasUsed": 108525,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 127269,
+  "gasUsed": 126974,
 }
 `;
 
@@ -283,69 +283,69 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 108782,
+  "gasUsed": 108360,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 261915,
+  "gasUsed": 260089,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 182727,
+  "gasUsed": 181602,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 116428,
+  "gasUsed": 116023,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 256770,
+  "gasUsed": 255199,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 178298,
+  "gasUsed": 177310,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 125350,
+  "gasUsed": 124822,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 133068,
+  "gasUsed": 132557,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 218591,
+  "gasUsed": 218192,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 128205,
+  "gasUsed": 127718,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,28 +3,28 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, both fail but the transaction succeeds 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 277705,
+  "gasUsed": 277708,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, neither fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 253398,
+  "gasUsed": 253401,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, second sub plan fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 253398,
+  "gasUsed": 253401,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, the first fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 277705,
+  "gasUsed": 277708,
 }
 `;
 
@@ -45,7 +45,7 @@ Object {
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, different input tokens, each two hop, with batch permit 1`] = `
 Object {
   "calldataByteLength": 1668,
-  "gasUsed": 301758,
+  "gasUsed": 301746,
 }
 `;
 
@@ -73,14 +73,14 @@ Object {
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 181336,
+  "gasUsed": 181339,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 181111,
+  "gasUsed": 181114,
 }
 `;
 
@@ -101,7 +101,7 @@ Object {
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1252,
-  "gasUsed": 196085,
+  "gasUsed": 196088,
 }
 `;
 
@@ -143,7 +143,7 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn trade, where an output fee is taken 1`] = `
 Object {
   "calldataByteLength": 900,
-  "gasUsed": 128604,
+  "gasUsed": 128607,
 }
 `;
 
@@ -213,14 +213,14 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 868,
-  "gasUsed": 129893,
+  "gasUsed": 129896,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, with ETH fee 1`] = `
 Object {
   "calldataByteLength": 1028,
-  "gasUsed": 137917,
+  "gasUsed": 137920,
 }
 `;
 

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
@@ -7,32 +7,32 @@ Object {
 }
 `;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1136520`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1129380`;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1171212`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1164107`;
 
 exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps SwapRouter02 1`] = `1124979`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3175891`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3155203`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3330699`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3310169`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps SwapRouter02 1`] = `3195011`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4226083`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4199806`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4431781`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4405716`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions SwapRouter02 1`] = `4282374`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `522191`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `519192`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `522509`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `519510`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap SwapRouter02 1`] = `500008`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `305396`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `304289`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `305332`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `304225`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap SwapRouter02 1`] = `270033`;

--- a/test/integration-tests/gas-tests/__snapshots__/V3ToV4Migration.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/V3ToV4Migration.gas.test.ts.snap
@@ -3,55 +3,55 @@
 exports[`V3 to V4 Migration Gas Tests V3 Commands burn gas: erc721permit + decreaseLiquidity + collect + burn 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 256990,
+  "gasUsed": 256923,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands collect gas: erc721permit + decreaseLiquidity + collect 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 224604,
+  "gasUsed": 224582,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands decrease liquidity gas: erc721permit + decreaseLiquidity 1`] = `
 Object {
   "calldataByteLength": 740,
-  "gasUsed": 202633,
+  "gasUsed": 202673,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands erc721permit gas: erc721permit 1`] = `
 Object {
   "calldataByteLength": 484,
-  "gasUsed": 66240,
+  "gasUsed": 66342,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands initialize pool gas: initialize a pool 1`] = `
 Object {
   "calldataByteLength": 452,
-  "gasUsed": 59115,
+  "gasUsed": 59262,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: migrate and mint 1`] = `
 Object {
   "calldataByteLength": 2500,
-  "gasUsed": 601001,
+  "gasUsed": 600514,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: migrate weth position into eth position with forwarding 1`] = `
 Object {
   "calldataByteLength": 2788,
-  "gasUsed": 577499,
+  "gasUsed": 577038,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: mint 1`] = `
 Object {
   "calldataByteLength": 1604,
-  "gasUsed": 446720,
+  "gasUsed": 446398,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/V3ToV4Migration.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/V3ToV4Migration.gas.test.ts.snap
@@ -3,55 +3,55 @@
 exports[`V3 to V4 Migration Gas Tests V3 Commands burn gas: erc721permit + decreaseLiquidity + collect + burn 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 257003,
+  "gasUsed": 256923,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands collect gas: erc721permit + decreaseLiquidity + collect 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 224616,
+  "gasUsed": 224582,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands decrease liquidity gas: erc721permit + decreaseLiquidity 1`] = `
 Object {
   "calldataByteLength": 740,
-  "gasUsed": 202641,
+  "gasUsed": 202673,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands erc721permit gas: erc721permit 1`] = `
 Object {
   "calldataByteLength": 484,
-  "gasUsed": 66244,
+  "gasUsed": 66342,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands initialize pool gas: initialize a pool 1`] = `
 Object {
   "calldataByteLength": 452,
-  "gasUsed": 59119,
+  "gasUsed": 59262,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: migrate and mint 1`] = `
 Object {
   "calldataByteLength": 2500,
-  "gasUsed": 601021,
+  "gasUsed": 600514,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: migrate weth position into eth position with forwarding 1`] = `
 Object {
   "calldataByteLength": 2788,
-  "gasUsed": 577515,
+  "gasUsed": 577038,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: mint 1`] = `
 Object {
   "calldataByteLength": 1604,
-  "gasUsed": 446724,
+  "gasUsed": 446398,
 }
 `;

--- a/test/integration-tests/shared/planner.ts
+++ b/test/integration-tests/shared/planner.ts
@@ -22,6 +22,7 @@ export enum CommandType {
   UNWRAP_WETH = 0x0c,
   PERMIT2_TRANSFER_FROM_BATCH = 0x0d,
   BALANCE_CHECK_ERC20 = 0x0e,
+  UNWRAP_WETH_EXACT = 0x0f,
 
   V4_SWAP = 0x10,
   V3_POSITION_MANAGER_PERMIT = 0x11,
@@ -70,6 +71,7 @@ const ABI_DEFINITION: { [key in CommandType]: string[] } = {
   // Token Actions and Checks
   [CommandType.WRAP_ETH]: ['address', 'uint256'],
   [CommandType.UNWRAP_WETH]: ['address', 'uint256'],
+  [CommandType.UNWRAP_WETH_EXACT]: ['address', 'uint256'],
   [CommandType.SWEEP]: ['address', 'address', 'uint256'],
   [CommandType.TRANSFER]: ['address', 'address', 'uint256'],
   [CommandType.PAY_PORTION]: ['address', 'address', 'uint256'],


### PR DESCRIPTION
## Summary

This change makes Universal Router command decoding respect each input's declared calldata boundary.

- Add minimum ABI head checks before raw dispatcher reads.
- Validate Permit2 batch struct and array bounds before assigning calldata pointers.
- Harden shared dynamic-array decoding against out-of-bounds offsets, truncated elements, and arithmetic overflow.
- Add selector and token ID bounds checks to position manager call validation.
- Correct the V4 hook guidance to distinguish the PoolManager caller from the hook sender parameter.
- Add regression coverage for zero-length signed input smuggling, short static and dynamic command inputs, and truncated Permit2 batches.

## Root cause

`executeSigned` hashes each input using its declared `bytes` length. Several dispatcher paths used `calldataload` beyond that declared length. Noncanonical outer ABI encoding could therefore leave executable command parameters after an empty or truncated signed input.

The fix is applied at the command decoder boundary so the same invariant holds for signed and regular execution.

## Validation

- `forge build --sizes`, UniversalRouter runtime size is 22,093 bytes with 2,483 bytes of margin.
- `FORK_URL=<configured> forge test --isolate -vv`, 111 tests passed.
- Selected Permit2 Hardhat integration tests, 3 tests passed.
- Scoped `forge fmt --check` and `forge lint` passed for all changed Solidity files.

The repository-wide formatting check remains blocked by the existing formatting of `test/foundry-tests/permissionedPools/PermissionedV4.t.sol`, which is unchanged by this PR.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Makes Universal Router command decoding respect each input's declared calldata boundary, preventing noncanonical outer ABI encoding from smuggling executable command parameters after an empty or truncated signed input. Also adds `UNWRAP_WETH_EXACT` (`0x0f`) for exact-amount WETH unwrapping.
## Root Cause
`executeSigned` hashes each input using its declared `bytes` length. Several dispatcher paths used `calldataload` beyond that declared length. Noncanonical outer ABI encoding could therefore leave executable command parameters after an empty or truncated signed input. The fix is applied at the command decoder boundary so the same invariant holds for signed and regular execution.
## Changes
- **Dispatcher**: Add `checkInputLength` minimum ABI head checks before raw `calldataload` reads for 15 static-head commands (V3/V2 swaps, PERMIT2_TRANSFER_FROM, SWEEP, TRANSFER, PAY_PORTION, WRAP_ETH, UNWRAP_WETH, BALANCE_CHECK_ERC20, V4_INITIALIZE_POOL, PERMIT2_PERMIT)
- **Dispatcher**: Replace inline Permit2 batch pointer assignment with `decodePermitBatch()` that validates struct offset, details array offset, and element count against input bounds
- **Dispatcher**: Remove two unreachable `revert InvalidCommandType` fallbacks in the saturated 0x00-0x07 and 0x08-0x0f dispatcher blocks
- **Dispatcher**: Decode SWEEP `amountMinimum` at full `uint256` width (was `uint160`)
- **Dispatcher**: Add `UNWRAP_WETH_EXACT` (`0x0f`) taking `(recipient, amount)`, which unwraps an exact amount of WETH and reverts with `InsufficientETH` if the balance is insufficient
- **BytesLib**: Add `toLengthOffset(bytes, uint256, uint256)` overload accepting an element size parameter; harden both variants against out-of-bounds offsets, truncated elements, and arithmetic overflow (division before multiplication)
- **V3ToV4Migrator**: Add minimum-length checks in `_checkV3PermitCall`, `_checkV3PositionManagerCall`, and `_checkV4PositionManagerCall` before `calldataload`
- **Payments**: Add `unwrapWETH9Exact(recipient, amount)` for exact-amount WETH unwrapping
- **IUniversalRouter**: Correct V4 hook NatSpec to distinguish the PoolManager caller (`msg.sender`) from the hook sender parameter
- **README**: Update command table to include `UNWRAP_WETH_EXACT` and fill in previously unlisted commands (`0x0e`-`0x14`)
- **planner.ts**: Add `UNWRAP_WETH_EXACT` enum value and ABI definition
## Tests
- Foundry: `testRejectsShortStaticCommandInputs` (15 commands), `testRejectsShortDynamicCommandInputs` (5 commands), `testPermit2PermitBatchDecodesBoundedDetails`, `testPermit2PermitBatchRejectsTruncatedDetails`, `testExecuteSignedRejectsSmuggledTransferInput`, `testFuzzTransferRejectsShortInput`, `testSweepTokenEnforcesFullWidthMinimum`, `testSweepTokenAtUint160MaxMinimum`
- Hardhat: 5 integration tests for `UNWRAP_WETH_EXACT` (partial unwrap, external recipient, full-balance, zero-amount no-op, insufficient balance revert)
- Gas snapshot for `UNWRAP_WETH_EXACT` partial unwrap added
- All gas snapshots regenerated
## Validation
- `forge build --sizes`: UniversalRouter runtime size is 22,093 bytes with 2,483 bytes of margin
- `forge test --isolate -vv`: 111 tests passed
- Selected Permit2 Hardhat integration tests: 3 tests passed
- `forge fmt --check` and `forge lint` passed for all changed Solidity files

</details>
<!-- claude-pr-description-end -->