### PR TITLE
fix(dispatcher): reject command inputs shorter than the fields they read

### DIFF
--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -34,6 +34,11 @@ abstract contract Dispatcher is
 
     error InvalidCommandType(uint256 commandType);
     error BalanceTooLow();
+    /// @dev Thrown when a command's input is shorter than the fixed fields that command reads.
+    /// Commands below read parameters with `calldataload` at fixed offsets. Without this check they
+    /// would read past `inputs.length` into adjacent calldata, which `executeSigned` never covered
+    /// with the EIP-712 input hash (that hash is taken over exactly `inputs[i].length` bytes).
+    error InvalidInputLength();
 
     /// @notice Executes encoded commands along with provided inputs.
     /// @param commands A set of concatenated commands, each 1 byte in length
@@ -65,6 +70,7 @@ abstract contract Dispatcher is
                 // 0x00 <= command < 0x08
                 if (command < Commands.V2_SWAP_EXACT_IN) {
                     if (command == Commands.V3_SWAP_EXACT_IN) {
+                        if (inputs.length < 0xc0) revert InvalidInputLength();
                         // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool, uint256[]))
                         address recipient;
                         uint256 amountIn;
@@ -82,6 +88,7 @@ abstract contract Dispatcher is
                         address payer = payerIsUser ? msgSender() : address(this);
                         v3SwapExactInput(map(recipient), amountIn, amountOutMin, path, payer, minHopPriceX36);
                     } else if (command == Commands.V3_SWAP_EXACT_OUT) {
+                        if (inputs.length < 0xc0) revert InvalidInputLength();
                         // equivalent: abi.decode(inputs, (address, uint256, uint256, bytes, bool, uint256[]))
                         address recipient;
                         uint256 amountOut;
@@ -99,6 +106,7 @@ abstract contract Dispatcher is
                         address payer = payerIsUser ? msgSender() : address(this);
                         v3SwapExactOutput(map(recipient), amountOut, amountInMax, path, payer, minHopPriceX36);
                     } else if (command == Commands.PERMIT2_TRANSFER_FROM) {
+                        if (inputs.length < 0x60) revert InvalidInputLength();
                         // equivalent: abi.decode(inputs, (address, address, uint160))
                         address token;
                         address recipient;
@@ -127,6 +135,7 @@ abstract contract Dispatcher is
                                 )
                             );
                     } else if (command == Commands.SWEEP) {
+                        if (inputs.length < 0x60) revert InvalidInputLength();
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
@@ -138,6 +147,7 @@ abstract contract Dispatcher is
                         }
                         Payments.sweep(token, map(recipient), amountMin);
                     } else if (command == Commands.TRANSFER) {
+                        if (inputs.length < 0x60) revert InvalidInputLength();
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
@@ -149,6 +159,7 @@ abstract contract Dispatcher is
                         }
                         Payments.pay(token, map(recipient), value);
                     } else if (command == Commands.PAY_PORTION) {
+                        if (inputs.length < 0x60) revert InvalidInputLength();
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
@@ -160,6 +171,7 @@ abstract contract Dispatcher is
                         }
                         Payments.payPortion(token, map(recipient), bips);
                     } else if (command == Commands.PAY_PORTION_FULL_PRECISION) {
+                        if (inputs.length < 0x60) revert InvalidInputLength();
                         // equivalent:  abi.decode(inputs, (address, address, uint256))
                         address token;
                         address recipient;
@@ -176,6 +188,7 @@ abstract contract Dispatcher is
                 } else {
                     // 0x08 <= command < 0x10
                     if (command == Commands.V2_SWAP_EXACT_IN) {
+                        if (inputs.length < 0xc0) revert InvalidInputLength();
                         // equivalent: abi.decode(inputs, (address, uint256, uint256, address[], bool, uint256[]))
                         address recipient;
                         uint256 amountIn;
@@ -193,6 +206,7 @@ abstract contract Dispatcher is
                         address payer = payerIsUser ? msgSender() : address(this);
                         v2SwapExactInput(map(recipient), amountIn, amountOutMin, path, payer, minHopPriceX36);
                     } else if (command == Commands.V2_SWAP_EXACT_OUT) {
+                        if (inputs.length < 0xc0) revert InvalidInputLength();
                         // equivalent: abi.decode(inputs, (address, uint256, uint256, address[], bool, uint256[]))
                         address recipient;
                         uint256 amountOut;
@@ -226,6 +240,7 @@ abstract contract Dispatcher is
                                 )
                             );
                     } else if (command == Commands.WRAP_ETH) {
+                        if (inputs.length < 0x40) revert InvalidInputLength();
                         // equivalent: abi.decode(inputs, (address, uint256))
                         address recipient;
                         uint256 amount;
@@ -235,6 +250,7 @@ abstract contract Dispatcher is
                         }
                         Payments.wrapETH(map(recipient), amount);
                     } else if (command == Commands.UNWRAP_WETH) {
+                        if (inputs.length < 0x40) revert InvalidInputLength();
                         // equivalent: abi.decode(inputs, (address, uint256))
                         address recipient;
                         uint256 amountMin;
@@ -252,6 +268,7 @@ abstract contract Dispatcher is
                         }
                         permit2TransferFrom(batchDetails, msgSender());
                     } else if (command == Commands.BALANCE_CHECK_ERC20) {
+                        if (inputs.length < 0x60) revert InvalidInputLength();
                         // equivalent: abi.decode(inputs, (address, address, uint256))
                         address owner;
                         address token;
@@ -281,6 +298,7 @@ abstract contract Dispatcher is
                     _checkV3PositionManagerCall(inputs, msgSender());
                     (success, output) = address(V3_POSITION_MANAGER).call(inputs);
                 } else if (command == Commands.V4_INITIALIZE_POOL) {
+                    if (inputs.length < 0xc0) revert InvalidInputLength();
                     PoolKey calldata poolKey;
                     uint160 sqrtPriceX96;
                     assembly {

--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "22177"
+  "UniversalRouter bytecode size": "22283"
 }

--- a/test/foundry-tests/DispatcherInputLength.t.sol
+++ b/test/foundry-tests/DispatcherInputLength.t.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import 'forge-std/Test.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {Dispatcher} from '../../contracts/base/Dispatcher.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {Constants} from '../../contracts/libraries/Constants.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+
+/// @notice Every command that reads fixed fields with `calldataload` must reject an input shorter
+/// than the bytes it reads. Without the guard those reads run past `inputs[i].length` into adjacent
+/// calldata — bytes that `executeSigned`'s EIP-712 input hash never covered.
+contract DispatcherInputLengthTest is Test {
+    address constant RECIPIENT = address(0x1234);
+
+    UniversalRouter router;
+
+    struct Case {
+        uint256 command;
+        uint256 minLength;
+        string name;
+    }
+
+    Case[] cases;
+
+    function setUp() public {
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            permissionsAdapterFactory: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0),
+            spokePool: address(0)
+        });
+        router = new UniversalRouter(params);
+
+        cases.push(Case(Commands.V3_SWAP_EXACT_IN, 0xc0, 'V3_SWAP_EXACT_IN'));
+        cases.push(Case(Commands.V3_SWAP_EXACT_OUT, 0xc0, 'V3_SWAP_EXACT_OUT'));
+        cases.push(Case(Commands.PERMIT2_TRANSFER_FROM, 0x60, 'PERMIT2_TRANSFER_FROM'));
+        cases.push(Case(Commands.SWEEP, 0x60, 'SWEEP'));
+        cases.push(Case(Commands.TRANSFER, 0x60, 'TRANSFER'));
+        cases.push(Case(Commands.PAY_PORTION, 0x60, 'PAY_PORTION'));
+        cases.push(Case(Commands.PAY_PORTION_FULL_PRECISION, 0x60, 'PAY_PORTION_FULL_PRECISION'));
+        cases.push(Case(Commands.V2_SWAP_EXACT_IN, 0xc0, 'V2_SWAP_EXACT_IN'));
+        cases.push(Case(Commands.V2_SWAP_EXACT_OUT, 0xc0, 'V2_SWAP_EXACT_OUT'));
+        cases.push(Case(Commands.WRAP_ETH, 0x40, 'WRAP_ETH'));
+        cases.push(Case(Commands.UNWRAP_WETH, 0x40, 'UNWRAP_WETH'));
+        cases.push(Case(Commands.BALANCE_CHECK_ERC20, 0x60, 'BALANCE_CHECK_ERC20'));
+        cases.push(Case(Commands.V4_INITIALIZE_POOL, 0xc0, 'V4_INITIALIZE_POOL'));
+    }
+
+    function _cmd(uint256 command) internal pure returns (bytes memory) {
+        return abi.encodePacked(bytes1(uint8(command)));
+    }
+
+    function _run(uint256 command, uint256 inputLength) internal {
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = new bytes(inputLength);
+        router.execute(_cmd(command), inputs);
+    }
+
+    /// @notice A zero-length input must revert for every fixed-field command.
+    function test_zeroLengthInput_revertsForEveryFixedFieldCommand() public {
+        for (uint256 i = 0; i < cases.length; ++i) {
+            vm.expectRevert(Dispatcher.InvalidInputLength.selector);
+            _run(cases[i].command, 0);
+        }
+    }
+
+    /// @notice One byte short of the required length must also revert — the boundary, not just zero.
+    function test_oneByteShort_revertsForEveryFixedFieldCommand() public {
+        for (uint256 i = 0; i < cases.length; ++i) {
+            vm.expectRevert(Dispatcher.InvalidInputLength.selector);
+            _run(cases[i].command, cases[i].minLength - 1);
+        }
+    }
+
+    /// @notice At exactly the required length the guard must not fire. These inputs are all-zero so
+    /// most commands still fail downstream; the assertion is only that the failure is never
+    /// InvalidInputLength.
+    function test_exactMinimumLength_doesNotRevertWithInvalidInputLength() public {
+        for (uint256 i = 0; i < cases.length; ++i) {
+            bytes[] memory inputs = new bytes[](1);
+            inputs[0] = new bytes(cases[i].minLength);
+            try router.execute(_cmd(cases[i].command), inputs) {
+                // guard did not fire
+            } catch (bytes memory reason) {
+                assertTrue(
+                    bytes4(reason) != Dispatcher.InvalidInputLength.selector,
+                    string.concat('guard fired at exact minimum length for ', cases[i].name)
+                );
+            }
+        }
+    }
+
+    /// @notice Positive control: a correctly encoded TRANSFER still works.
+    function test_correctlyEncodedTransfer_stillSucceeds() public {
+        uint256 amount = 1 ether;
+        vm.deal(address(this), amount);
+
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(Constants.ETH, RECIPIENT, amount);
+        assertEq(inputs[0].length, 0x60, 'payload is 3 words');
+
+        router.execute{value: amount}(_cmd(Commands.TRANSFER), inputs);
+
+        assertEq(RECIPIENT.balance, amount, 'recipient received the transfer');
+    }
+
+    /// @notice The concrete shape from Cantina #703: a signature-covered empty input with three
+    /// attacker-chosen words parked immediately after the zero length word. Reaching dispatch with
+    /// `inputs[0].length == 0` is now rejected outright.
+    function test_smuggledWordsAfterZeroLength_areRejected() public {
+        vm.deal(address(this), 1 ether);
+
+        bytes memory callData = abi.encodeWithSelector(
+            bytes4(keccak256('execute(bytes,bytes[])')), _cmd(Commands.TRANSFER), _singleInput()
+        );
+        _zeroFirstInputLengthWord(callData);
+
+        (bool success, bytes memory returnData) = address(router).call{value: 1 ether}(callData);
+
+        assertFalse(success, 'smuggled execution must not succeed');
+        assertEq(bytes4(returnData), Dispatcher.InvalidInputLength.selector, 'must revert InvalidInputLength');
+        assertEq(RECIPIENT.balance, 0, 'recipient must receive nothing');
+    }
+
+    function _singleInput() internal pure returns (bytes[] memory inputs) {
+        inputs = new bytes[](1);
+        inputs[0] = abi.encode(Constants.ETH, RECIPIENT, uint256(1 ether));
+    }
+
+    /// @notice Rewrites the first `bytes` element's length word to zero, leaving its three data
+    /// words physically present in calldata. This is the non-canonical encoding the finding relies
+    /// on: the decoder reports an empty input while the words remain readable via `calldataload`.
+    function _zeroFirstInputLengthWord(bytes memory callData) internal pure {
+        uint256 argsStart;
+        assembly {
+            argsStart := add(add(callData, 0x20), 0x04)
+        }
+
+        uint256 inputsOffset;
+        assembly {
+            inputsOffset := mload(add(argsStart, 0x20))
+        }
+        uint256 inputsStart = argsStart + inputsOffset;
+
+        uint256 arrayLength;
+        assembly {
+            arrayLength := mload(inputsStart)
+        }
+        require(arrayLength == 1, 'bad inputs length');
+
+        uint256 firstInputOffset;
+        assembly {
+            firstInputOffset := mload(add(inputsStart, 0x20))
+        }
+
+        uint256 firstInputLengthPtr = inputsStart + firstInputOffset;
+        uint256 firstInputLength;
+        assembly {
+            firstInputLength := mload(firstInputLengthPtr)
+        }
+
+        if (firstInputLength != 0x60) {
+            firstInputLengthPtr = inputsStart + 0x20 + firstInputOffset;
+            assembly {
+                firstInputLength := mload(firstInputLengthPtr)
+            }
+        }
+        require(firstInputLength == 0x60, 'bad first input length');
+
+        assembly {
+            mstore(firstInputLengthPtr, 0)
+        }
+    }
+}

--- a/test/foundry-tests/DispatcherInputLength.t.sol
+++ b/test/foundry-tests/DispatcherInputLength.t.sol
@@ -89,8 +89,9 @@ contract DispatcherInputLengthTest is Test {
             bytes[] memory inputs = new bytes[](1);
             inputs[0] = new bytes(cases[i].minLength);
             try router.execute(_cmd(cases[i].command), inputs) {
-                // guard did not fire
-            } catch (bytes memory reason) {
+            // guard did not fire
+            }
+            catch (bytes memory reason) {
                 assertTrue(
                     bytes4(reason) != Dispatcher.InvalidInputLength.selector,
                     string.concat('guard fired at exact minimum length for ', cases[i].name)

--- a/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Check Ownership Gas gas: balance check ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 37904,
+  "gasUsed": 37918,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -3,48 +3,48 @@
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 37301,
+  "gasUsed": 37321,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 66081,
+  "gasUsed": 66121,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 36205,
+  "gasUsed": 36225,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ETH 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 31764,
+  "gasUsed": 31784,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 44998,
+  "gasUsed": 45018,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 51432,
+  "gasUsed": 51492,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: WRAP_ETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 53675,
+  "gasUsed": 53691,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,105 +3,105 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, both fail but the transaction succeeds 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 279169,
+  "gasUsed": 279255,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, neither fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 254827,
+  "gasUsed": 254913,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, second sub plan fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 254827,
+  "gasUsed": 254913,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, the first fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 279169,
+  "gasUsed": 279255,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V2, then V3 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 195036,
+  "gasUsed": 195080,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V3, then V2 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 182301,
+  "gasUsed": 182345,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, different input tokens, each two hop, with batch permit 1`] = `
 Object {
   "calldataByteLength": 1668,
-  "gasUsed": 303496,
+  "gasUsed": 303540,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit 1`] = `
 Object {
   "calldataByteLength": 1348,
-  "gasUsed": 313888,
+  "gasUsed": 313966,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit transfer from batch 1`] = `
 Object {
   "calldataByteLength": 1412,
-  "gasUsed": 315213,
+  "gasUsed": 315257,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, without explicit permit 1`] = `
 Object {
   "calldataByteLength": 1028,
-  "gasUsed": 310470,
+  "gasUsed": 310514,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 182486,
+  "gasUsed": 182550,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 182261,
+  "gasUsed": 182325,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, exactOut, one hop 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 197587,
+  "gasUsed": 197651,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 190490,
+  "gasUsed": 190554,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1252,
-  "gasUsed": 197179,
+  "gasUsed": 197263,
 }
 `;
 
@@ -143,98 +143,98 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn trade, where an output fee is taken 1`] = `
 Object {
   "calldataByteLength": 900,
-  "gasUsed": 129238,
+  "gasUsed": 129300,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 109217,
+  "gasUsed": 109239,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 245370,
+  "gasUsed": 245392,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops, no deadline 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 245112,
+  "gasUsed": 245134,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 177333,
+  "gasUsed": 177355,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops, MSG_SENDER flag 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 177333,
+  "gasUsed": 177355,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 108370,
+  "gasUsed": 108392,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 250378,
+  "gasUsed": 250400,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 179439,
+  "gasUsed": 179461,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 125737,
+  "gasUsed": 125779,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 868,
-  "gasUsed": 130284,
+  "gasUsed": 130346,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, with ETH fee 1`] = `
 Object {
   "calldataByteLength": 1028,
-  "gasUsed": 138162,
+  "gasUsed": 138244,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 109045,
+  "gasUsed": 109087,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 127269,
+  "gasUsed": 127331,
 }
 `;
 
@@ -283,69 +283,69 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 108782,
+  "gasUsed": 108804,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 261915,
+  "gasUsed": 261937,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 182727,
+  "gasUsed": 182749,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 116428,
+  "gasUsed": 116450,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 256770,
+  "gasUsed": 256792,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 178298,
+  "gasUsed": 178320,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 125350,
+  "gasUsed": 125392,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 133068,
+  "gasUsed": 133110,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 218591,
+  "gasUsed": 218633,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 128205,
+  "gasUsed": 128267,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
@@ -7,32 +7,32 @@ Object {
 }
 `;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1136520`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1136674`;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1171212`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1171366`;
 
 exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps SwapRouter02 1`] = `1124979`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3175891`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3176331`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3330699`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3331139`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps SwapRouter02 1`] = `3195011`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4226083`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4226633`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4431781`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4432331`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions SwapRouter02 1`] = `4282374`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `522191`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `522257`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `522509`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `522575`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap SwapRouter02 1`] = `500008`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `305396`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `305418`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `305332`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `305354`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap SwapRouter02 1`] = `270033`;

--- a/test/integration-tests/gas-tests/__snapshots__/V3ToV4Migration.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/V3ToV4Migration.gas.test.ts.snap
@@ -31,7 +31,7 @@ Object {
 exports[`V3 to V4 Migration Gas Tests V4 Commands initialize pool gas: initialize a pool 1`] = `
 Object {
   "calldataByteLength": 452,
-  "gasUsed": 59119,
+  "gasUsed": 59136,
 }
 `;
 
@@ -45,7 +45,7 @@ Object {
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: migrate weth position into eth position with forwarding 1`] = `
 Object {
   "calldataByteLength": 2788,
-  "gasUsed": 577515,
+  "gasUsed": 577547,
 }
 `;
 


### PR DESCRIPTION
## Summary

Addresses [Cantina #703](https://cantina.xyz/code/f9df94db-c7b1-434b-bb06-d1360abdd1be/findings/703) (duplicate #809).

Commands that decode fixed fields with `calldataload` read at fixed offsets from `inputs.offset` without consulting `inputs.length`. Solidity's ABI decoder accepts non-canonical calldata where a `bytes[]` element declares a short (or zero) length while attacker-chosen words remain physically present immediately after the length word — so those reads can run past the declared end of the input.

This matters for `executeSigned`. `RouteSigner._setSignatureContext` hashes each input as `keccak256(inputs[i])`, covering exactly `inputs[i].length` bytes. Anything read beyond that length was never covered by the EIP-712 signature, so the router can authenticate one byte range and execute a different one — contradicting the guarantee documented at `IUniversalRouter.sol:52` that all commands are covered by the signature.

The inline `// equivalent: abi.decode(inputs, (...))` comments are also inaccurate today: `abi.decode` reverts on insufficient data, `calldataload` returns whatever is at the offset. These guards make the comments true.

## Change

Adds `error InvalidInputLength()` and a minimum-length guard to the 13 commands that read fixed fields:

| Guard | Commands |
|---|---|
| `0x40` | `WRAP_ETH`, `UNWRAP_WETH` |
| `0x60` | `PERMIT2_TRANSFER_FROM`, `SWEEP`, `TRANSFER`, `PAY_PORTION`, `PAY_PORTION_FULL_PRECISION`, `BALANCE_CHECK_ERC20` |
| `0xC0` | `V3_SWAP_EXACT_IN`, `V3_SWAP_EXACT_OUT`, `V2_SWAP_EXACT_IN`, `V2_SWAP_EXACT_OUT`, `V4_INITIALIZE_POOL` |

Nine of these have no bounds-checked decoder behind them and are directly affected. The four V2/V3 swap paths are already saved incidentally by `toBytes` / `toAddressArray` / `toUint256Array`, which revert `SliceOutOfBounds()` on a truncated input. They are guarded anyway so nobody has to re-derive per-command reachability later.

`>=` rather than `==` is deliberate: bytes past the required minimum are still inside the declared length, so they are covered by the signature hash and harmless. Requiring an exact length would break any integrator that pads, on the public `execute()` path, for no security gain — and it cannot express the swap commands, whose length is legitimately variable.

## Severity

Low, in our assessment. An attacker cannot tamper with a well-formed signed route — changing the declared length changes `keccak256(inputs[i])` and invalidates the signature. Exploitation requires the signer to have already signed a malformed short input, which no correctly built signer produces and no attacker can induce. No funds are at risk today, since nothing in production consumes `signedRouteContext()`.

Worth fixing regardless: in a correct implementation a signer mistake of this kind is self-correcting (the route just reverts). Today it is exploitable instead, and "do not sign malformed inputs" is an undocumented requirement.

## Testing

New `test/foundry-tests/DispatcherInputLength.t.sol` — 5 tests, all passing:

- zero-length input rejected for all 13 commands
- one byte short rejected for all 13 commands (boundary, not just zero)
- exact minimum length not over-rejected
- correctly encoded `TRANSFER` still succeeds
- the concrete #703 shape — zero length word with three words parked after it — rejected

Verified the tests are load-bearing: with the guards stripped, 3 of the 5 fail, including `"smuggled execution must not succeed"` — i.e. without the guard the smuggled execution succeeds.

Full `forge test` shows an identical failure set to `main` (fork tests needing RPC access, plus pre-existing unrelated failures). No regressions.

Bytecode size 22177 → 22283 (+106 bytes).

**Not done in this PR:** hardhat gas snapshots. `FORK_URL` was unavailable locally so the integration tests could not run. Each guarded command gains a few gas, so `test/integration-tests/gas-tests/__snapshots__/*.snap` will need regenerating.

## Note on #489

[#489](https://github.com/Uniswap/universal-router/pull/489) adds `UNWRAP_WETH_AMOUNT` (`0x0f`), which uses the same unguarded `calldataload` pattern and would be a 14th site. Whichever of the two merges second should add the corresponding `0x60` guard. Deliberately not coupled here, since #489 has its own open design questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Addresses [Cantina #703](https://cantina.xyz/code/f9df94db-c7b1-434b-bb06-d1360abdd1be/findings/703) (duplicate #809). Commands that decode fixed fields with `calldataload` read at fixed offsets without consulting `inputs.length`, allowing reads past the declared end of the input. This matters for `executeSigned`, where `keccak256(inputs[i])` covers exactly `inputs[i].length` bytes — anything read beyond that was never covered by the EIP-712 signature.
## Changes
- Add `error InvalidInputLength()` and minimum-length guards to all 13 commands that read fixed fields via `calldataload` in `Dispatcher.sol`:
| Guard | Commands |
|---|---|
| `0x40` | `WRAP_ETH`, `UNWRAP_WETH` |
| `0x60` | `PERMIT2_TRANSFER_FROM`, `SWEEP`, `TRANSFER`, `PAY_PORTION`, `PAY_PORTION_FULL_PRECISION`, `BALANCE_CHECK_ERC20` |
| `0xC0` | `V3_SWAP_EXACT_IN`, `V3_SWAP_EXACT_OUT`, `V2_SWAP_EXACT_IN`, `V2_SWAP_EXACT_OUT`, `V4_INITIALIZE_POOL` |
- Update bytecode size snapshot: 22177 → 22283 (+106 bytes)
- Update gas snapshots for all integration test suites
- Add `test/foundry-tests/DispatcherInputLength.t.sol` with 5 tests covering zero-length, boundary (one byte short), exact minimum length, correctly encoded TRANSFER, and the concrete #703 smuggled-words shape
## Notes
- Uses `>=` rather than `==`: bytes past the required minimum are still inside the declared length and covered by the signature hash. Exact-length checks would break integrators that pad inputs and cannot express variable-length swap commands
- Nine of the 13 commands are directly affected; the four V2/V3 swap paths are incidentally saved by `toBytes`/`toAddressArray`/`toUint256Array` but are guarded anyway so per-command reachability doesn't need re-derivation
- Severity is low: exploitation requires the signer to have already signed a malformed short input, which no correctly built signer produces
- [#489](https://github.com/Uniswap/universal-router/pull/489) adds `UNWRAP_WETH_AMOUNT` (`0x0f`), which uses the same pattern and would need a 14th guard — whichever PR merges second should add it

</details>
<!-- claude-pr-description-end -->