### PR TITLE
fix(payments): sweep permissions-adapter currencies as their underlying token

### DIFF
--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -6,6 +6,7 @@ import {V3SwapRouter} from '../modules/uniswap/v3/V3SwapRouter.sol';
 import {V4SwapRouter} from '../modules/uniswap/v4/V4SwapRouter.sol';
 import {BytesLib} from '../modules/uniswap/v3/BytesLib.sol';
 import {Payments} from '../modules/Payments.sol';
+import {Constants} from '../libraries/Constants.sol';
 import {PaymentsImmutables} from '../modules/PaymentsImmutables.sol';
 import {V3ToV4Migrator} from '../modules/V3ToV4Migrator.sol';
 import {Commands} from '../libraries/Commands.sol';
@@ -136,6 +137,14 @@ abstract contract Dispatcher is
                             token := calldataload(inputs.offset)
                             recipient := calldataload(add(inputs.offset, 0x20))
                             amountMin := calldataload(add(inputs.offset, 0x40))
+                        }
+                        // An adapter unwraps on arrival, so the router only ever holds the underlying.
+                        // Sweeping the adapter would read an always-zero balance and strand the underlying.
+                        // ETH short-circuits: Constants.ETH is address(0), which is never an adapter, so
+                        // the lookup would be both wasted and reliant on the factory returning zero for it.
+                        if (token != Constants.ETH && address(PERMISSIONS_ADAPTER_FACTORY) != address(0)) {
+                            address underlying = PERMISSIONS_ADAPTER_FACTORY.verifiedPermissionsAdapterOf(token);
+                            if (underlying != address(0)) token = underlying;
                         }
                         Payments.sweep(token, map(recipient), amountMin);
                     } else if (command == Commands.TRANSFER) {

--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "22574"
+  "UniversalRouter bytecode size": "22785"
 }

--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "22785"
+  "UniversalRouter bytecode size": "23705"
 }

--- a/test/foundry-tests/permissionedPools/PermissionedSweep.t.sol
+++ b/test/foundry-tests/permissionedPools/PermissionedSweep.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import 'forge-std/Test.sol';
+import {UniversalRouter} from '../../../contracts/UniversalRouter.sol';
+import {Payments} from '../../../contracts/modules/Payments.sol';
+import {Commands} from '../../../contracts/libraries/Commands.sol';
+import {Constants} from '../../../contracts/libraries/Constants.sol';
+import {RouterParameters} from '../../../contracts/types/RouterParameters.sol';
+import {MockERC20} from '../mock/MockERC20.sol';
+
+/// @notice Resolves exactly one address to a fixed underlying, and zero for everything else.
+/// @dev The adapter address is never called, so it does not need to be a contract. Deliberately resolves
+///      address(0) to a non-zero sentinel: a real factory returns zero there, but relying on that would make
+///      ETH sweeps depend on a foreign contract's behaviour, so the dispatcher short-circuits ETH instead.
+///      Any regression in that short-circuit surfaces as a failing ETH sweep here.
+contract MockPermissionsAdapterFactory {
+    address public immutable adapter;
+    address public immutable underlying;
+    address public constant ZERO_RESOLVES_TO = address(0xBADE7);
+
+    constructor(address _adapter, address _underlying) {
+        adapter = _adapter;
+        underlying = _underlying;
+    }
+
+    function verifiedPermissionsAdapterOf(address token) external view returns (address) {
+        if (token == address(0)) return ZERO_RESOLVES_TO;
+        return token == adapter ? underlying : address(0);
+    }
+}
+
+/// @notice Covers Dispatcher's SWEEP adapter-resolution branch, which is unreachable in the rest of the
+///         suite because every other fixture deploys the router with the factory unset.
+contract PermissionedSweepTest is Test {
+    address constant RECIPIENT = address(1234);
+    address constant ADAPTER = address(0xADA9741E4);
+    uint256 constant AMOUNT = 10 ** 18;
+
+    UniversalRouter router;
+    MockERC20 underlying;
+    MockERC20 ordinary;
+
+    function setUp() public {
+        underlying = new MockERC20();
+        ordinary = new MockERC20();
+        RouterParameters memory params;
+        params.permissionsAdapterFactory = address(new MockPermissionsAdapterFactory(ADAPTER, address(underlying)));
+        router = new UniversalRouter(params);
+    }
+
+    function _sweep(address token, uint256 amountMin) internal {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.SWEEP)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(token, RECIPIENT, amountMin);
+        router.execute(commands, inputs);
+    }
+
+    /// @dev Sweeping the adapter must deliver the underlying the router actually holds. Without the
+    ///      substitution this reads balanceOf(ADAPTER) == 0 and silently transfers nothing.
+    function test_sweep_adapterDeliversUnderlying() public {
+        underlying.mint(address(router), AMOUNT);
+
+        _sweep(ADAPTER, AMOUNT);
+
+        assertEq(underlying.balanceOf(RECIPIENT), AMOUNT);
+        assertEq(underlying.balanceOf(address(router)), 0);
+    }
+
+    /// @dev amountMinimum is enforced against the underlying balance, not the adapter's zero balance.
+    function test_sweep_adapterRevertsBelowAmountMinimum() public {
+        underlying.mint(address(router), AMOUNT);
+
+        vm.expectRevert(Payments.InsufficientToken.selector);
+        _sweep(ADAPTER, AMOUNT + 1);
+    }
+
+    /// @dev Negative case: a token the factory does not resolve is swept as itself, unchanged.
+    function test_sweep_nonAdapterTokenUnaffected() public {
+        ordinary.mint(address(router), AMOUNT);
+
+        _sweep(address(ordinary), AMOUNT);
+
+        assertEq(ordinary.balanceOf(RECIPIENT), AMOUNT);
+    }
+
+    /// @dev ETH sweeps must work with a live factory. Constants.ETH is address(0), which the resolution
+    ///      short-circuits before ever reaching the factory.
+    function test_sweep_ethWithLiveFactory() public {
+        vm.deal(address(router), AMOUNT);
+
+        _sweep(Constants.ETH, AMOUNT);
+
+        assertEq(RECIPIENT.balance, AMOUNT);
+        assertEq(address(router).balance, 0);
+    }
+}

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 37348,
+  "gasUsed": 37446,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 66142,
+  "gasUsed": 66240,
 }
 `;
 
@@ -45,7 +45,7 @@ Object {
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 51494,
+  "gasUsed": 51551,
 }
 `;
 

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,28 +3,28 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, both fail but the transaction succeeds 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 277708,
+  "gasUsed": 277806,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, neither fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 253401,
+  "gasUsed": 253499,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, second sub plan fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 253401,
+  "gasUsed": 253499,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, the first fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 277708,
+  "gasUsed": 277806,
 }
 `;
 
@@ -73,14 +73,14 @@ Object {
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 181339,
+  "gasUsed": 181437,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 181114,
+  "gasUsed": 181212,
 }
 `;
 
@@ -101,7 +101,7 @@ Object {
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1252,
-  "gasUsed": 196088,
+  "gasUsed": 196186,
 }
 `;
 
@@ -143,7 +143,7 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn trade, where an output fee is taken 1`] = `
 Object {
   "calldataByteLength": 900,
-  "gasUsed": 128607,
+  "gasUsed": 128705,
 }
 `;
 
@@ -213,14 +213,14 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 868,
-  "gasUsed": 129896,
+  "gasUsed": 129994,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, with ETH fee 1`] = `
 Object {
   "calldataByteLength": 1028,
-  "gasUsed": 137920,
+  "gasUsed": 137977,
 }
 `;
 


### PR DESCRIPTION
- In the SWEEP command, a permissions-adapter currency is resolved to its underlying permissioned token before sweeping. Taking an adapter to the router unwraps it, so the router only ever holds the underlying. ETH and ordinary tokens are unaffected (short-circuited before the factory lookup).
- Adds tests for adapter, non-adapter, and ETH sweeps.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
In the `SWEEP` command, a permissions-adapter currency is resolved to its underlying permissioned token before sweeping. Taking an adapter to the router unwraps it, so the router only ever holds the underlying. Sweeping the adapter address would read an always-zero `balanceOf` and silently strand the underlying tokens.
## Root cause
When a permissioned token is sent to the router via its adapter, the adapter unwraps on arrival and the router holds the underlying ERC20. A `SWEEP` targeting the adapter address calls `balanceOf(adapter)` which returns zero — transferring nothing and leaving the underlying stuck in the router.
## Changes
- **`Dispatcher.sol`**: Before calling `Payments.sweep`, check whether `token` resolves to a permissions adapter via `PERMISSIONS_ADAPTER_FACTORY.verifiedPermissionsAdapterOf(token)`. If it does, substitute the underlying address. ETH (`address(0)`) and chains with no factory (`address(0)`) short-circuit before the lookup.
- **`PermissionedSweep.t.sol`**: New Foundry test file with a `MockPermissionsAdapterFactory` covering four cases: adapter resolves to underlying, `amountMinimum` enforced against underlying balance, non-adapter token unaffected, and ETH sweep works with a live factory.
- **Gas snapshots**: Updated for the additional bytecode (22574 → 23705) and minor gas increases (~98 gas on SWEEP paths due to the factory-address check).
- **`lib/v4-periphery`**: Bumped to current main.
## Notes
- The factory check (`address(PERMISSIONS_ADAPTER_FACTORY) != address(0)`) is a no-op on chains where permissioned pools are disabled, so existing behavior is unchanged.
- The ETH short-circuit (`token != Constants.ETH`) avoids a wasted external call and removes any dependence on the factory's behavior for `address(0)` inputs.

</details>
<!-- claude-pr-description-end -->