### PR TITLE
docs: note the per-hop bound donation limitation in V2 and V3

### DIFF
--- a/contracts/modules/uniswap/v2/V2SwapRouter.sol
+++ b/contracts/modules/uniswap/v2/V2SwapRouter.sol
@@ -30,6 +30,9 @@ abstract contract V2SwapRouter is UniswapImmutables, Permit2Payments {
                 (uint256 reserve0, uint256 reserve1,) = IUniswapV2Pair(pair).getReserves();
                 (uint256 reserveInput, uint256 reserveOutput) =
                     input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+                // Note: amountInput is the pair's whole balance excess, so it counts tokens any third party transferred in.
+                // A larger apparent trade earns a worse average rate, so a donation drives the price below minHopPriceX36 and
+                // reverts. The pair's permissionless skim() then returns the donation.
                 uint256 amountInput = ERC20(input).balanceOf(pair) - reserveInput;
                 uint256 amountOutput = UniswapV2Library.getAmountOut(amountInput, reserveInput, reserveOutput);
                 (uint256 amount0Out, uint256 amount1Out) =

--- a/contracts/modules/uniswap/v3/V3SwapRouter.sol
+++ b/contracts/modules/uniswap/v3/V3SwapRouter.sol
@@ -112,6 +112,9 @@ abstract contract V3SwapRouter is UniswapImmutables, Permit2Payments, IUniswapV3
         ) revert V3HopPriceAndPathLengthMismatch();
 
         // use amountIn == ActionConstants.CONTRACT_BALANCE as a flag to swap the entire balance of the contract
+        // Note: balanceOf includes tokens any third party sent to the router, so a donation enlarges the trade.
+        // The larger trade earns a worse average rate, which can trip minHopPriceX36 and revert the route, and SWEEP
+        // takes an arbitrary recipient so the donation is recoverable.
         if (amountIn == ActionConstants.CONTRACT_BALANCE) {
             address tokenIn = path.decodeFirstToken();
             amountIn = ERC20(tokenIn).balanceOf(address(this));


### PR DESCRIPTION
Audit finding L-01 (Low). The V2 per-hop bound divides by `balanceOf(pair) - reserveInput`, which counts tokens any third party can transfer to the pair. A larger apparent trade earns a worse average rate, so a donation drives the measured price under minHopPriceX36 and reverts a bounded route. The pair's permissionless skim() returns the donation afterwards, so censorship costs the attacker only gas and ordering.

No funds are at risk and the bound never lets bad execution through; the failure is a spurious revert, which is why this is Low.

Not fixing it in this release. The correct primitive requires routing to emit different per-hop values, and the encoding migration needs deciding first -- the field's meaning would change without its type changing, so a stale caller would be silently misread rather than rejected. Fixing in the next version.

Also notes the related V3 exposure: when amountIn == CONTRACT_BALANCE the router seeds amountIn from its own balance, so a donation to the router enlarges the trade the same way and SWEEP takes an arbitrary recipient, which makes it recoverable.

Comments only. Bytecode is unchanged at 23,705 bytes, matching the existing snapshot.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

Audit finding L-01 (Low). The V2 per-hop bound divides by `balanceOf(pair) - reserveInput`, which counts tokens any third party can transfer to the pair. A larger apparent trade earns a worse average rate, so a donation drives the measured price under `minHopPriceX36` and reverts a bounded route. The pair's permissionless `skim()` returns the donation afterwards, so censorship costs the attacker only gas and ordering.
No funds are at risk and the bound never lets bad execution through; the failure is a spurious revert, which is why this is Low.
Not fixing it in this release. The correct primitive requires routing to emit different per-hop values, and the encoding migration needs deciding first — the field's meaning would change without its type changing, so a stale caller would be silently misread rather than rejected. Fixing in the next version.
Also notes the related V3 exposure: when `amountIn == CONTRACT_BALANCE` the router seeds `amountIn` from its own balance, so a donation to the router enlarges the trade the same way, and `SWEEP` takes an arbitrary recipient, which makes it recoverable.
## Changes
- **`V2SwapRouter.sol`**: Add inline comment on `amountInput` explaining that `balanceOf(pair) - reserveInput` counts third-party donations, which can trip `minHopPriceX36` and revert bounded routes
- **`V3SwapRouter.sol`**: Add inline comment on the `CONTRACT_BALANCE` branch explaining the same donation vector via the router's own balance, noting that `SWEEP` makes donations recoverable
## Notes
- Comments only — bytecode is unchanged at 23,705 bytes, matching the existing snapshot

</details>
<!-- claude-pr-description-end -->