### PR TITLE
chore: bump v4-periphery to abi.decode swap param decoders

### DIFF
--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "24092"
+  "UniversalRouter bytecode size": "24500"
 }

--- a/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/CheckOwnership.gas.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Check Ownership Gas gas: balance check ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 38057,
+  "gasUsed": 38027,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Payments.gas.test.ts.snap
@@ -3,55 +3,55 @@
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 37496,
+  "gasUsed": 37466,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: SWEEP_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 516,
-  "gasUsed": 66290,
+  "gasUsed": 66230,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ERC20 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 36410,
+  "gasUsed": 36380,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: TRANSFER with ETH 1`] = `
 Object {
   "calldataByteLength": 356,
-  "gasUsed": 31972,
+  "gasUsed": 31942,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 45022,
+  "gasUsed": 44992,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_EXACT partial amount 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 49948,
+  "gasUsed": 49918,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: UNWRAP_WETH_WITH_FEE 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 51601,
+  "gasUsed": 51511,
 }
 `;
 
 exports[`Payments Gas Tests Individual Command Tests gas: WRAP_ETH 1`] = `
 Object {
   "calldataByteLength": 324,
-  "gasUsed": 53788,
+  "gasUsed": 53764,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,105 +3,105 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, both fail but the transaction succeeds 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 277944,
+  "gasUsed": 277830,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, neither fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 253637,
+  "gasUsed": 253523,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, second sub plan fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 253637,
+  "gasUsed": 253523,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, the first fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 277944,
+  "gasUsed": 277830,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V2, then V3 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 193817,
+  "gasUsed": 193790,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V3, then V2 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 181354,
+  "gasUsed": 181327,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, different input tokens, each two hop, with batch permit 1`] = `
 Object {
   "calldataByteLength": 1668,
-  "gasUsed": 301796,
+  "gasUsed": 301706,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit 1`] = `
 Object {
   "calldataByteLength": 1348,
-  "gasUsed": 312349,
+  "gasUsed": 312229,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, with explicit permit transfer from batch 1`] = `
 Object {
   "calldataByteLength": 1412,
-  "gasUsed": 313444,
+  "gasUsed": 313354,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V2 different routes, each two hop, without explicit permit 1`] = `
 Object {
   "calldataByteLength": 1028,
-  "gasUsed": 308641,
+  "gasUsed": 308581,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 181531,
+  "gasUsed": 181474,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 181306,
+  "gasUsed": 181249,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, exactOut, one hop 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 196865,
+  "gasUsed": 196808,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 189364,
+  "gasUsed": 189307,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1252,
-  "gasUsed": 196280,
+  "gasUsed": 196193,
 }
 `;
 
@@ -143,98 +143,98 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn trade, where an output fee is taken 1`] = `
 Object {
   "calldataByteLength": 900,
-  "gasUsed": 128755,
+  "gasUsed": 128665,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 108655,
+  "gasUsed": 108625,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 244233,
+  "gasUsed": 244203,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops, no deadline 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 243925,
+  "gasUsed": 243895,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 176481,
+  "gasUsed": 176451,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops, MSG_SENDER flag 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 176481,
+  "gasUsed": 176451,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 108207,
+  "gasUsed": 108177,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 644,
-  "gasUsed": 249542,
+  "gasUsed": 249512,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 178945,
+  "gasUsed": 178915,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 125069,
+  "gasUsed": 125009,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 868,
-  "gasUsed": 130044,
+  "gasUsed": 129954,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ERC20 --> ETH gas: exactOut, with ETH fee 1`] = `
 Object {
   "calldataByteLength": 1028,
-  "gasUsed": 138027,
+  "gasUsed": 137907,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 108575,
+  "gasUsed": 108515,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV2 with Universal Router. ETH --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 127024,
+  "gasUsed": 126934,
 }
 `;
 
@@ -283,69 +283,69 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 108454,
+  "gasUsed": 108457,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 260271,
+  "gasUsed": 260340,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 181740,
+  "gasUsed": 181776,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 116117,
+  "gasUsed": 116120,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 255381,
+  "gasUsed": 255450,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 177448,
+  "gasUsed": 177484,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 124916,
+  "gasUsed": 124889,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 132651,
+  "gasUsed": 132624,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 218286,
+  "gasUsed": 218259,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 127812,
+  "gasUsed": 127755,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
@@ -7,32 +7,32 @@ Object {
 }
 `;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1129820`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1129910`;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1164547`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1164577`;
 
 exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps SwapRouter02 1`] = `1124979`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3156523`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3156883`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3311489`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3311579`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps SwapRouter02 1`] = `3195011`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4201566`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4202046`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4407476`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4407596`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions SwapRouter02 1`] = `4282374`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `519368`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `519380`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `519686`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `519698`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap SwapRouter02 1`] = `500008`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `304377`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `304383`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `304313`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `304319`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap SwapRouter02 1`] = `270033`;

--- a/test/integration-tests/gas-tests/__snapshots__/V3ToV4Migration.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/V3ToV4Migration.gas.test.ts.snap
@@ -3,55 +3,55 @@
 exports[`V3 to V4 Migration Gas Tests V3 Commands burn gas: erc721permit + decreaseLiquidity + collect + burn 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 256963,
+  "gasUsed": 256867,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands collect gas: erc721permit + decreaseLiquidity + collect 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 224632,
+  "gasUsed": 224542,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands decrease liquidity gas: erc721permit + decreaseLiquidity 1`] = `
 Object {
   "calldataByteLength": 740,
-  "gasUsed": 202723,
+  "gasUsed": 202663,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V3 Commands erc721permit gas: erc721permit 1`] = `
 Object {
   "calldataByteLength": 484,
-  "gasUsed": 66392,
+  "gasUsed": 66362,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands initialize pool gas: initialize a pool 1`] = `
 Object {
   "calldataByteLength": 452,
-  "gasUsed": 59312,
+  "gasUsed": 59282,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: migrate and mint 1`] = `
 Object {
   "calldataByteLength": 2500,
-  "gasUsed": 600564,
+  "gasUsed": 600414,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: migrate weth position into eth position with forwarding 1`] = `
 Object {
   "calldataByteLength": 2788,
-  "gasUsed": 577078,
+  "gasUsed": 576910,
 }
 `;
 
 exports[`V3 to V4 Migration Gas Tests V4 Commands mint gas: mint 1`] = `
 Object {
   "calldataByteLength": 1604,
-  "gasUsed": 446448,
+  "gasUsed": 446418,
 }
 `;


### PR DESCRIPTION
Points `lib/v4-periphery` at Uniswap/v4-periphery#593 (`0cc6e164`), which replaces the assembly struct-pointer assignment in the four V4 swap param decoders with `abi.decode`, so dynamic members are bounded by `params.length` rather than `calldatasize()`.

This matters here specifically: `RouteSigner` hashes each command input at its declared length, so under the old decoding a member could begin inside `params` and extend past `params.length` — letting a declared route and an executed route diverge. Bumping the submodule is what actually closes that in the router.

Stacked on #502 so the bytecode number below reflects both changes together.

## Bytecode

| | Runtime size | Free under 24,576 |
|---|---|---|
| #502 alone | 24,092 | 484 |
| With this bump | 24,500 | **76** |

**+408 bytes, leaving 76 bytes of headroom.** That is larger than the 274 bytes the periphery PR measured against `V4Router` — UniversalRouter compiles at `optimizer_runs = 1` (`compilation_restrictions` in `foundry.toml`), and the calldata→memory conversion propagates through `_swap`, the four `_swap*` helpers, and `PathKeyLibrary.getPoolAndSwapDirection`, so the copy-to-memory code inlines at more sites. Confirmed on a `forge build --force` clean build.

76 bytes is effectively no headroom. Not addressing that in this PR — worth a separate look at reclaiming size before this line ships.

## Gas snapshots

Regenerated. All 66 changed entries are `gasUsed` only; no `calldataByteLength` changed and no functional behavior changed. Deltas run −168 to +480: the multi-swap UX benchmarks regress ~30 gas per swap, most individual-command benchmarks improve ~30 gas. Both directions look like optimizer layout shifts at `optimizer_runs = 1` rather than a uniform per-swap cost — the Hardhat V4 coverage is migration and mint, not V4 swaps, so the decoder's own swap cost is not exercised by these benchmarks.

Also bumps the `UniversalRouter bytecode size` Foundry snapshot to 24,500.

## Verification

- `forge test --isolate` — 139 passed, 0 failed
- `yarn test:hardhat` — 190 passing, 0 failing (re-run without `UPDATE_SNAPSHOT` to confirm CI parity)
- Baseline confirmed clean on #502 before regenerating, so these snapshot updates carry only this bump's drift
- Submodule bump is a fast-forward (`07336f21` is an ancestor of `0cc6e164`); also picks up docs-only #590

Note: local Foundry is 1.5.1, CI pins 1.4.3 — the exact byte count could shift slightly on CI.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

Points `lib/v4-periphery` at Uniswap/v4-periphery#593 (`0cc6e164`), which replaces the assembly struct-pointer assignment in the four V4 swap param decoders with `abi.decode`, so dynamic members are bounded by `params.length` rather than `calldatasize()`.
This matters here specifically: `RouteSigner` hashes each command input at its declared length, so under the old decoding a member could begin inside `params` and extend past `params.length` — letting a declared route and an executed route diverge. Bumping the submodule is what actually closes that in the router.
Stacked on #502 so the bytecode number below reflects both changes together.
## Bytecode
| | Runtime size | Free under 24,576 |
|---|---|---|
| #502 alone | 24,092 | 484 |
| With this bump | 24,500 | **76** |
**+408 bytes, leaving 76 bytes of headroom.** That is larger than the 274 bytes the periphery PR measured against `V4Router` — UniversalRouter compiles at `optimizer_runs = 1` (`compilation_restrictions` in `foundry.toml`), and the calldata-to-memory conversion propagates through `_swap`, the four `_swap*` helpers, and `PathKeyLibrary.getPoolAndSwapDirection`, so the copy-to-memory code inlines at more sites. Confirmed on a `forge build --force` clean build.
76 bytes is effectively no headroom. Not addressing that in this PR — worth a separate look at reclaiming size before this line ships.
## Changes
- **`lib/v4-periphery`**: Bump submodule from `07336f21` to `0cc6e164` (fast-forward; also picks up docs-only #590)
- **`snapshots/UniversalRouterTest.json`**: Update bytecode size from 24,092 to 24,500
- **Gas snapshots**: All 66 changed entries are `gasUsed` only; no `calldataByteLength` changed and no functional behavior changed. Deltas run −168 to +480 — optimizer layout shifts at `optimizer_runs = 1`, not a uniform per-swap cost
## Verification
- `forge test --isolate` — 139 passed, 0 failed
- `yarn test:hardhat` — 190 passing, 0 failing
- Baseline confirmed clean on #502 before regenerating, so these snapshot updates carry only this bump's drift
- Local Foundry is 1.5.1, CI pins 1.4.3 — the exact byte count could shift slightly on CI

</details>
<!-- claude-pr-description-end -->