### PR TITLE
feat: add V3_PROTOCOL_FEE_UPDATE command to poke the v3 fee controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Each command is a `bytes1` containing the following 8 bits:
    ├──────┼───────────────────────────────┤
    │ 0x16 │  V4_PROTOCOL_FEE_UPDATE       │
    ├──────┼───────────────────────────────┤
-   │ 0x17-│  -------                      │
+   │ 0x17 │  V3_PROTOCOL_FEE_UPDATE       │
+   ├──────┼───────────────────────────────┤
+   │ 0x18-│  -------                      │
    │ 0x20 │                               │
    ├──────┼───────────────────────────────┤
    │ 0x21 │  EXECUTE_SUB_PLAN             │
@@ -116,7 +118,9 @@ Note that some of the commands in the middle of the series are unused. These gap
 
 `UNWRAP_WETH_EXACT` takes `(recipient, amount)` and unwraps an exact amount of the contract's WETH, reverting if the balance is insufficient.
 
-`RESOLVE` takes `(address resolver, bytes context)` and performs a bounded, read-only `staticcall` to `resolver.resolveAmount(context)` (see `IAmountResolver`), storing the returned value in a transient register. A later command in the same plan can then use that value as an amount by passing the `Constants.USE_RESOLVED_AMOUNT` sentinel (`1 << 127`, which fits the `uint128` v4 amount fields) in place of a literal — supported by the v2/v3 swap amount fields, the `amountIn`/`amountOut` of every v4 swap action inside `V4_SWAP`, and `TRANSFER`. This lets a route obtain an amount that is only known onchain at execution time (for example, a live lending-position debt) instead of baking an offchain guess into calldata. The register is transaction-scoped: it survives across commands and into an `EXECUTE_SUB_PLAN`, and is cleared when the top-level `execute` returns. Because the resolver is invoked via `staticcall` and at most one word of returndata is copied, a resolver can neither mutate state nor grief the router with a return bomb; a resolver that reverts is subject to the usual `FLAG_ALLOW_REVERT` semantics.
+`RESOLVE` takes `(address resolver, bytes context)` and performs a bounded, read-only `staticcall` to `resolver.resolveAmount(context)` (see `IAmountResolver`), storing the returned value in a transient register. A later command in the same plan can then use that value as an amount by passing the `Constants.USE_RESOLVED_AMOUNT` sentinel (`1 << 127`, which fits the `uint128` v4 amount fields) in place of a literal. That sentinel is honored by the v2/v3 swap amount fields, the `amountIn`/`amountOut` of every v4 swap action inside `V4_SWAP`, and `TRANSFER`. This lets a route obtain an amount that is only known onchain at execution time (for example, a live lending-position debt) instead of baking an offchain guess into calldata. The register is transaction-scoped: it survives across commands and into an `EXECUTE_SUB_PLAN`, and is cleared when the top-level `execute` returns. Because the resolver is invoked via `staticcall` and at most one word of returndata is copied, a resolver can neither mutate state nor grief the router with a return bomb; a resolver that reverts is subject to the usual `FLAG_ALLOW_REVERT` semantics.
+
+`V4_PROTOCOL_FEE_UPDATE` takes `(PoolKey key)` and `V3_PROTOCOL_FEE_UPDATE` takes `(address pool)`. Each pokes the protocol fee adapter that governance installed as the controller (the v4 `PoolManager.protocolFeeController()`, or the v3 factory `owner()`), read onchain so the router holds no adapter address, which pushes that pool's resolved protocol fee into pool state. Newly created pools initialize with no protocol fee, so a route can activate it in the same transaction as the first swap rather than waiting on the offchain keeper. The poke follows the same failure semantics as the other call-based commands: it surfaces as `ExecutionFailed` unless `FLAG_ALLOW_REVERT` is set, and on a chain with no adapter installed the call targets `address(0)` and is a no-op, so one route shape works on every chain.
 
 #### How the input bytes are structures
 

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -14,6 +14,8 @@ import {Commands} from '../libraries/Commands.sol';
 import {ResolvedAmount} from '../libraries/ResolvedAmount.sol';
 import {IAmountResolver} from '../interfaces/IAmountResolver.sol';
 import {IV4FeeAdapter} from '../interfaces/external/IV4FeeAdapter.sol';
+import {IV3FeeAdapter} from '../interfaces/external/IV3FeeAdapter.sol';
+import {IUniswapV3Factory} from '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import {IProtocolFees} from '@uniswap/v4-core/src/interfaces/IProtocolFees.sol';
 import {Lock} from './Lock.sol';
 import {ERC20} from 'solmate/src/tokens/ERC20.sol';
@@ -370,8 +372,18 @@ abstract contract Dispatcher is
                     // adapter address and follows any future controller change.
                     (success, output) = IProtocolFees(address(poolManager)).protocolFeeController()
                         .call(abi.encodeCall(IV4FeeAdapter.triggerFeeUpdate, (poolKey)));
+                } else if (command == Commands.V3_PROTOCOL_FEE_UPDATE) {
+                    checkInputLength(inputs, 0x20);
+                    // equivalent: abi.decode(inputs, (address))
+                    address pool;
+                    assembly {
+                        pool := calldataload(inputs.offset)
+                    }
+                    // The v3 fee adapter owns the v3 factory; read it onchain and poke it for this pool.
+                    (success, output) = IUniswapV3Factory(UNISWAP_V3_FACTORY).owner()
+                        .call(abi.encodeCall(IV3FeeAdapter.triggerFeeUpdate, (pool)));
                 } else {
-                    // placeholder area for commands 0x17-0x20
+                    // placeholder area for commands 0x18-0x20
                     revert InvalidCommandType(command);
                 }
             }

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -42,7 +42,6 @@ abstract contract Dispatcher is
 
     error InvalidCommandType(uint256 commandType);
     error BalanceTooLow();
-    error NotSelf();
     /// @notice Thrown when a route reaches V4_SWAP inside a foreign PoolManager unlock without opting in
     error NestedExecutionNotPermitted();
 
@@ -50,20 +49,6 @@ abstract contract Dispatcher is
     /// @param commands A set of concatenated commands, each 1 byte in length
     /// @param inputs An array of byte strings containing abi encoded inputs for each command
     function execute(bytes calldata commands, bytes[] calldata inputs) external payable virtual;
-
-    /// @notice Runs the v4 actions of a V4_SWAP command inside a PoolManager unlock opened elsewhere
-    /// @param inputs The V4_SWAP command input, re-encoded by the dispatcher
-    /// @dev Only callable by this contract. It exists so that `inputs` arrives as a freshly abi encoded
-    /// calldata copy rather than as a slice of the original transaction calldata. The v4 parameter decoders
-    /// follow offsets without bounding them against the enclosing input, so a slice would let them read
-    /// bytes past `inputs.length` -- bytes that executeSigned never commits to. Encoding the argument makes
-    /// calldata end where the input ends, which is the same guarantee poolManager.unlock() gives the
-    /// ordinary path when it re-encodes for unlockCallback.
-    function executeV4SwapWithinUnlock(bytes calldata inputs) external {
-        if (msg.sender != address(this)) revert NotSelf();
-        (bytes calldata actions, bytes[] calldata params) = inputs.decodeActionsRouterParams();
-        _executeActionsWithoutUnlock(actions, params);
-    }
 
     /// @notice Public view function to be used instead of msg.sender, as the contract performs self-reentrancy and at
     /// times msg.sender == address(this). Instead msgSender() returns the initiator of the lock
@@ -332,7 +317,12 @@ abstract contract Dispatcher is
                         // Nesting shares the router's delta account with every other call in this
                         // unlock, so it runs only when the caller explicitly opted in via executeNested.
                         if (!NestedUnlock.isPermitted()) revert NestedExecutionNotPermitted();
-                        this.executeV4SwapWithinUnlock(inputs);
+                        // The v4 swap parameter decoders (v4-periphery) bound every struct and member offset
+                        // against the input length via abi.decode, so decoding directly from this calldata
+                        // slice cannot read past inputs[i].length. Coverage: V4NestedMemberSmuggle.t.sol and
+                        // V4NestedUnlockCalldataSmuggling.t.sol.
+                        (bytes calldata actions, bytes[] calldata params) = inputs.decodeActionsRouterParams();
+                        _executeActionsWithoutUnlock(actions, params);
                     } else {
                         // pass the calldata provided to V4SwapRouter._executeActions (defined in BaseActionsRouter)
                         _executeActions(inputs);

--- a/contracts/interfaces/external/IV3FeeAdapter.sol
+++ b/contracts/interfaces/external/IV3FeeAdapter.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+/// @title IV3FeeAdapter
+/// @notice The permissionless entrypoint of the v3 protocol fee adapter that owns the v3 factory.
+interface IV3FeeAdapter {
+    /// @notice Sets the protocol fee for an initialized v3 pool to the value the adapter resolves for it
+    /// @dev A no-op for uninitialized/nonexistent pools
+    function triggerFeeUpdate(address pool) external;
+}

--- a/contracts/libraries/Commands.sol
+++ b/contracts/libraries/Commands.sol
@@ -39,7 +39,8 @@ library Commands {
     uint256 constant V4_POSITION_MANAGER_CALL = 0x14;
     uint256 constant RESOLVE = 0x15;
     uint256 constant V4_PROTOCOL_FEE_UPDATE = 0x16;
-    // COMMAND_PLACEHOLDER = 0x17 -> 0x20
+    uint256 constant V3_PROTOCOL_FEE_UPDATE = 0x17;
+    // COMMAND_PLACEHOLDER = 0x18 -> 0x20
 
     // Command Types where 0x21<=value<=0x3f
     uint256 constant EXECUTE_SUB_PLAN = 0x21;

--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "24243"
+  "UniversalRouter bytecode size": "24428"
 }

--- a/snapshots/UniversalRouterTest.json
+++ b/snapshots/UniversalRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "UniversalRouter bytecode size": "24390"
+  "UniversalRouter bytecode size": "24243"
 }

--- a/test/foundry-tests/V3ProtocolFeeUpdate.t.sol
+++ b/test/foundry-tests/V3ProtocolFeeUpdate.t.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {Test} from 'forge-std/Test.sol';
+import {CalldataDecoder} from '@uniswap/v4-periphery/src/libraries/CalldataDecoder.sol';
+
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {IUniversalRouter} from '../../contracts/interfaces/IUniversalRouter.sol';
+import {MockV3FeeAdapter, RevertingV3FeeAdapter, MockV3Factory} from './mock/MockV3FeeAdapter.sol';
+
+/// @notice Exercises V3_PROTOCOL_FEE_UPDATE end to end: the router reads the v3 factory owner (the fee adapter)
+/// and pokes it for the given pool.
+contract V3ProtocolFeeUpdateTest is Test {
+    address constant POOL = address(0xBEEF);
+
+    UniversalRouter router;
+    MockV3Factory factory;
+    MockV3FeeAdapter adapter;
+
+    function setUp() public {
+        factory = new MockV3Factory();
+        adapter = new MockV3FeeAdapter();
+        factory.setOwner(address(adapter));
+
+        RouterParameters memory params = RouterParameters({
+            permit2: address(0),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(factory),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(0),
+            permissionsAdapterFactory: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0),
+            spokePool: address(0)
+        });
+        router = new UniversalRouter(params);
+    }
+
+    function _plan(address pool, bool allowRevert)
+        internal
+        pure
+        returns (bytes memory commands, bytes[] memory inputs)
+    {
+        uint8 command = uint8(Commands.V3_PROTOCOL_FEE_UPDATE);
+        if (allowRevert) command |= uint8(Commands.FLAG_ALLOW_REVERT);
+        commands = abi.encodePacked(bytes1(command));
+        inputs = new bytes[](1);
+        inputs[0] = abi.encode(pool);
+    }
+
+    function test_v3ProtocolFeeUpdate_pokesFactoryOwnerForPool() public {
+        (bytes memory commands, bytes[] memory inputs) = _plan(POOL, false);
+        router.execute(commands, inputs);
+
+        assertEq(adapter.calls(), 1);
+        assertEq(adapter.lastPool(), POOL);
+        assertEq(adapter.lastCaller(), address(router));
+    }
+
+    function test_v3ProtocolFeeUpdate_revertBubblesWhenRequired() public {
+        factory.setOwner(address(new RevertingV3FeeAdapter()));
+        (bytes memory commands, bytes[] memory inputs) = _plan(POOL, false);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IUniversalRouter.ExecutionFailed.selector,
+                uint256(0),
+                abi.encodeWithSelector(RevertingV3FeeAdapter.PokeRejected.selector)
+            )
+        );
+        router.execute(commands, inputs);
+    }
+
+    function test_v3ProtocolFeeUpdate_allowRevertContinues() public {
+        factory.setOwner(address(new RevertingV3FeeAdapter()));
+        (bytes memory commands, bytes[] memory inputs) = _plan(POOL, true);
+        router.execute(commands, inputs);
+    }
+
+    /// @dev With no adapter set as factory owner the poke targets address(0) and is a no-op rather than a
+    /// route failure, so a route built for every chain does not need a per-chain command set.
+    function test_v3ProtocolFeeUpdate_noOwnerIsNoop() public {
+        factory.setOwner(address(0));
+        (bytes memory commands, bytes[] memory inputs) = _plan(POOL, false);
+        router.execute(commands, inputs);
+    }
+
+    function test_v3ProtocolFeeUpdate_shortInputReverts() public {
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V3_PROTOCOL_FEE_UPDATE)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = bytes('');
+
+        vm.expectRevert(CalldataDecoder.SliceOutOfBounds.selector);
+        router.execute(commands, inputs);
+    }
+}

--- a/test/foundry-tests/V4NestedMemberSmuggle.t.sol
+++ b/test/foundry-tests/V4NestedMemberSmuggle.t.sol
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {Test} from 'forge-std/Test.sol';
+import {Deployers} from '@uniswap/v4-core/test/utils/Deployers.sol';
+import {IPoolManager} from '@uniswap/v4-core/src/interfaces/IPoolManager.sol';
+import {IUnlockCallback} from '@uniswap/v4-core/src/interfaces/callback/IUnlockCallback.sol';
+import {Currency} from '@uniswap/v4-core/src/types/Currency.sol';
+import {IHooks} from '@uniswap/v4-core/src/interfaces/IHooks.sol';
+import {MockERC20} from 'solmate/src/test/utils/mocks/MockERC20.sol';
+import {IAllowanceTransfer} from 'permit2/src/interfaces/IAllowanceTransfer.sol';
+
+import {Plan, Planner} from '@uniswap/v4-periphery/test/shared/Planner.sol';
+import {Actions} from '@uniswap/v4-periphery/src/libraries/Actions.sol';
+import {ActionConstants} from '@uniswap/v4-periphery/src/libraries/ActionConstants.sol';
+import {IV4Router} from '@uniswap/v4-periphery/src/interfaces/IV4Router.sol';
+import {PathKey} from '@uniswap/v4-periphery/src/libraries/PathKey.sol';
+
+import {UniversalRouter} from '../../contracts/UniversalRouter.sol';
+import {RouterParameters} from '../../contracts/types/RouterParameters.sol';
+import {Commands} from '../../contracts/libraries/Commands.sol';
+import {Permit2AllowanceMock} from './V4SwapWithinUnlock.t.sol';
+import {RawLockHolder} from './V4NestedUnlockCalldataSmuggling.t.sol';
+
+/// @notice Member-offset smuggling (finding BP-2): the ExactInputParams struct offset stays canonical at 0x20
+///         while the *path* member offset is redirected to bytes appended past inputs[0].length. The escaping
+///         member is the whole PathKey (intermediate currency, fee, tick spacing and the hooks address), so
+///         this is the variant a struct-offset-only fix leaves live. The in-bounds path array is blanked,
+///         so any swap that executes was routed through bytes outside the declared, signature-covered input.
+contract V4NestedMemberSmuggleTest is Test, Deployers {
+    UniversalRouter router;
+    RawLockHolder holder;
+
+    address constant RECIPIENT = address(0xBEEF);
+    uint128 constant AMOUNT_IN = 1e15;
+
+    // Byte offsets within executeNested(bytes,bytes[],uint256) calldata for a one-command / one-input plan whose
+    // single action is SWAP_EXACT_IN with a 1-hop path (SETTLE + TAKE follow). Read off the calldata dump; the
+    // ExactInputParams struct head sits one word past the params[0] struct-offset word.
+    uint256 constant PARAMS0_LEN_WORD = 0x204; // value 0x1e0
+    uint256 constant STRUCT_OFFSET_WORD = 0x224; // value 0x20 (stays canonical, which is the point of BP-2)
+    uint256 constant STRUCT_HEAD = 0x244; // ExactInputParams word 0 (currencyIn); offsets are relative to here
+    uint256 constant PATH_OFFSET_WORD = 0x264; // ExactInputParams word 1 (path); value 0xa0 -> blank + redirect
+    uint256 constant PATH_ARRAY_START = 0x2e4; // in-bounds path array (length word)
+    uint256 constant MINHOP_ARRAY_START = 0x3e4; // in-bounds minHopPriceX36 length word (blank up to here)
+
+    function setUp() public {
+        deployFreshManagerAndRouters();
+        (currency0, currency1) = deployMintAndApprove2Currencies();
+        (key,) = initPoolAndAddLiquidity(currency0, currency1, IHooks(address(0)), 3000, SQRT_PRICE_1_1);
+        IAllowanceTransfer permit2 = IAllowanceTransfer(address(new Permit2AllowanceMock()));
+
+        RouterParameters memory params = RouterParameters({
+            permit2: address(permit2),
+            weth9: address(0),
+            v2Factory: address(0),
+            v3Factory: address(0),
+            pairInitCodeHash: bytes32(0),
+            poolInitCodeHash: bytes32(0),
+            v4PoolManager: address(manager),
+            permissionsAdapterFactory: address(0),
+            v3NFTPositionManager: address(0),
+            v4PositionManager: address(0),
+            spokePool: address(0)
+        });
+        router = new UniversalRouter(params);
+        holder = new RawLockHolder(IPoolManager(address(manager)), router);
+        MockERC20(Currency.unwrap(currency0)).transfer(address(router), 10e18);
+    }
+
+    /// @dev A 1-hop exact-in currency0 -> currency1 plan (SWAP_EXACT_IN multi-hop form), settle from the
+    ///      router balance, take output to RECIPIENT.
+    function _plan() internal view returns (bytes memory) {
+        PathKey[] memory path = new PathKey[](1);
+        path[0] = PathKey({
+            intermediateCurrency: currency1, fee: 3000, tickSpacing: 60, hooks: IHooks(address(0)), hookData: hex''
+        });
+        IV4Router.ExactInputParams memory sp = IV4Router.ExactInputParams({
+            currencyIn: currency0,
+            path: path,
+            minHopPriceX36: new uint256[](0),
+            amountIn: AMOUNT_IN,
+            amountOutMinimum: 0
+        });
+        Plan memory plan = Planner.init();
+        plan = plan.add(Actions.SWAP_EXACT_IN, abi.encode(sp));
+        plan = plan.add(Actions.SETTLE, abi.encode(currency0, ActionConstants.OPEN_DELTA, false));
+        plan = plan.add(Actions.TAKE, abi.encode(currency1, RECIPIENT, ActionConstants.OPEN_DELTA));
+        return plan.encode();
+    }
+
+    function _word(bytes memory blob, uint256 pos) internal pure returns (uint256 v) {
+        assembly ('memory-safe') {
+            v := mload(add(add(blob, 0x20), pos))
+        }
+    }
+
+    function _setWord(bytes memory blob, uint256 pos, uint256 v) internal pure {
+        assembly ('memory-safe') {
+            mstore(add(add(blob, 0x20), pos), v)
+        }
+    }
+
+    /// @dev Builds the smuggling payload and returns it. The declared path array is blanked in place; the real
+    ///      1-hop path is appended past the encoding and the path member offset is redirected to it.
+    function _buildSmugglePayload() internal view returns (bytes memory payload) {
+        bytes memory planBlob = _plan();
+        bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V4_SWAP)));
+        bytes[] memory inputs = new bytes[](1);
+        inputs[0] = planBlob;
+
+        // The smuggled path: the same encoding the declared path had, appended verbatim past the input end.
+        PathKey[] memory smuggledPath = new PathKey[](1);
+        smuggledPath[0] = PathKey({
+            intermediateCurrency: currency1, fee: 3000, tickSpacing: 60, hooks: IHooks(address(0)), hookData: hex''
+        });
+        bytes memory tail = abi.encode(smuggledPath);
+
+        payload = bytes.concat(
+            abi.encodeWithSignature('executeNested(bytes,bytes[],uint256)', commands, inputs, type(uint256).max), tail
+        );
+
+        // Guard the layout: struct offset canonical, path member offset at its known value, params length known.
+        require(_word(payload, STRUCT_OFFSET_WORD) == 0x20, 'layout: struct offset moved');
+        require(_word(payload, PATH_OFFSET_WORD) == 0xa0, 'layout: path member offset moved');
+        require(_word(payload, PARAMS0_LEN_WORD) == 0x1e0, 'layout: params[0] length moved');
+
+        // Blank the in-bounds path array so a canonical decode sees an empty path: any swap that runs must have
+        // followed the redirected offset into the tail.
+        for (uint256 i = PATH_ARRAY_START; i < MINHOP_ARRAY_START; i++) {
+            payload[i] = 0x00;
+        }
+
+        // abi.encode(PathKey[]) prefixes a 0x20 offset word, so the array length word sits one word into the
+        // tail. Point the path member offset (relative to STRUCT_HEAD) there. The struct offset itself is
+        // untouched and still canonical.
+        uint256 arrayLenWord = (payload.length - tail.length) + 0x20;
+        _setWord(payload, PATH_OFFSET_WORD, arrayLenWord - STRUCT_HEAD);
+    }
+
+    /// @notice Security regression: passes on a build that blocks the member-offset smuggle, fails on one that
+    ///         executes it. The abi.decode swap decoders bound every member offset against the input length, so
+    ///         this passes with the nested branch decoding directly from its calldata slice. It was confirmed
+    ///         to fail against the earlier assembly decoders, so it is a real exploit, not a vacuous assertion.
+    function test_pathMemberRedirect_cannotReachSmuggledBytes() public {
+        bytes memory payload = _buildSmugglePayload();
+
+        uint256 routerBefore = MockERC20(Currency.unwrap(currency0)).balanceOf(address(router));
+        uint256 recipientBefore = MockERC20(Currency.unwrap(currency1)).balanceOf(RECIPIENT);
+
+        holder.attack(payload);
+
+        assertEq(
+            MockERC20(Currency.unwrap(currency0)).balanceOf(address(router)),
+            routerBefore,
+            'no input may be spent via a path sourced past the declared input'
+        );
+        assertEq(
+            MockERC20(Currency.unwrap(currency1)).balanceOf(RECIPIENT),
+            recipientBefore,
+            'no output may be delivered via a smuggled path'
+        );
+    }
+
+    /// @notice Non-asserting: logs the actual outcome so the per-config behavior is visible from -vv even when
+    ///         the asserting test above fails.
+    function test_pathMemberRedirect_logOutcome() public {
+        bytes memory payload = _buildSmugglePayload();
+        uint256 routerBefore = MockERC20(Currency.unwrap(currency0)).balanceOf(address(router));
+        uint256 recipientBefore = MockERC20(Currency.unwrap(currency1)).balanceOf(RECIPIENT);
+
+        holder.attack(payload);
+
+        uint256 spent = routerBefore - MockERC20(Currency.unwrap(currency0)).balanceOf(address(router));
+        uint256 delivered = MockERC20(Currency.unwrap(currency1)).balanceOf(RECIPIENT) - recipientBefore;
+        emit log_named_uint('router call succeeded (1/0)', holder.callSucceeded() ? 1 : 0);
+        emit log_named_uint('currency0 spent from router', spent);
+        emit log_named_uint('currency1 delivered to recipient', delivered);
+        if (spent > 0 || delivered > 0) {
+            emit log_string('SMUGGLE EXECUTED: swap routed through bytes outside inputs[0].length');
+        } else {
+            emit log_string('SMUGGLE BLOCKED: redirected path member reached no executable route');
+        }
+    }
+}

--- a/test/foundry-tests/V4NestedUnlockCalldataSmuggling.t.sol
+++ b/test/foundry-tests/V4NestedUnlockCalldataSmuggling.t.sol
@@ -48,14 +48,15 @@ contract RawLockHolder is IUnlockCallback {
     }
 }
 
-/// @notice Regression coverage for the nested-unlock V4_SWAP path decoding from a canonical copy of its input.
+/// @notice Regression coverage for the nested-unlock V4_SWAP path: a redirected struct offset cannot reach
+///         bytes past the declared input.
 ///
-/// The v4 swap parameter decoders in CalldataDecoder follow the struct offset in the first word of `params`
-/// without bounding it against `params.length`. On the ordinary path that is inert, because
-/// `poolManager.unlock()` re-encodes the input for `unlockCallback` and calldata therefore ends where the
-/// input ends. The nested-unlock branch used to hand the decoders a slice of the original transaction
-/// calldata instead, which let a redirected struct offset reach bytes past `inputs[i].length` -- bytes that
-/// `executeSigned` never commits to. `Dispatcher.executeV4SwapWithinUnlock` restores the re-encode.
+/// The v4 swap parameter decoders in CalldataDecoder use abi.decode, which bounds the struct offset (and every
+/// dynamic member) against `params.length`. A redirected offset therefore reverts rather than reading bytes
+/// past `inputs[i].length`, bytes that `executeSigned` never commits to. This holds on both paths and does
+/// not depend on the caller re-encoding the input first, so the nested branch decodes directly from its
+/// calldata slice. The member-offset variant, which a struct-offset-only fix would miss, is in
+/// V4NestedMemberSmuggle.t.sol.
 contract V4NestedUnlockCalldataSmugglingTest is Test, Deployers {
     UniversalRouter router;
     RawLockHolder holder;
@@ -125,7 +126,7 @@ contract V4NestedUnlockCalldataSmugglingTest is Test, Deployers {
     ///      appended verbatim past the end of the encoding.
     /// @dev The nested entrypoint is required here: plain execute() now refuses to reuse an unlock it did not
     ///      open, so the smuggling attempts have to opt in the same way a real composer would. An attacker can
-    ///      opt themselves in, which is precisely why the re-encode remains load-bearing.
+    ///      opt themselves in, which is why the decoders themselves must bound the offsets.
     function _rawCalldata(bytes memory planBlob, bytes memory tail) internal pure returns (bytes memory) {
         bytes memory commands = abi.encodePacked(bytes1(uint8(Commands.V4_SWAP)));
         bytes[] memory inputs = new bytes[](1);
@@ -274,12 +275,6 @@ contract V4NestedUnlockCalldataSmugglingTest is Test, Deployers {
             routerBefore,
             'no funds may move on the ordinary path'
         );
-    }
-
-    /// @notice Only this contract may drive the nested action runner.
-    function test_executeV4SwapWithinUnlock_revertsForExternalCallers() public {
-        vm.expectRevert(abi.encodeWithSignature('NotSelf()'));
-        router.executeV4SwapWithinUnlock(_plan(SMUGGLED_AMOUNT));
     }
 
     /// @dev needle search restricted to [from, to)

--- a/test/foundry-tests/mock/MockV3FeeAdapter.sol
+++ b/test/foundry-tests/mock/MockV3FeeAdapter.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {IV3FeeAdapter} from '../../../contracts/interfaces/external/IV3FeeAdapter.sol';
+
+/// @notice Stands in for the v3 protocol fee adapter that owns the v3 factory: records each poke the way the
+/// real adapter would before pushing a fee into the pool.
+contract MockV3FeeAdapter is IV3FeeAdapter {
+    uint256 public calls;
+    address public lastPool;
+    address public lastCaller;
+
+    function triggerFeeUpdate(address pool) external {
+        calls++;
+        lastPool = pool;
+        lastCaller = msg.sender;
+    }
+}
+
+/// @notice A v3 fee adapter whose poke always reverts, to exercise the failure path.
+contract RevertingV3FeeAdapter is IV3FeeAdapter {
+    error PokeRejected();
+
+    function triggerFeeUpdate(address) external pure {
+        revert PokeRejected();
+    }
+}
+
+/// @notice Minimal v3 factory exposing only owner(), which the router reads to find the fee adapter.
+contract MockV3Factory {
+    address public owner;
+
+    function setOwner(address newOwner) external {
+        owner = newOwner;
+    }
+}

--- a/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/Uniswap.gas.test.ts.snap
@@ -3,42 +3,42 @@
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, both fail but the transaction succeeds 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 277891,
+  "gasUsed": 277847,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, neither fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 253609,
+  "gasUsed": 253565,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, second sub plan fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 253609,
+  "gasUsed": 253565,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Batch reverts gas: 2 sub-plans, the first fails 1`] = `
 Object {
   "calldataByteLength": 1956,
-  "gasUsed": 277891,
+  "gasUsed": 277847,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V2, then V3 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 193885,
+  "gasUsed": 193863,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Interleaving routes gas: V3, then V2 1`] = `
 Object {
   "calldataByteLength": 964,
-  "gasUsed": 181390,
+  "gasUsed": 181368,
 }
 `;
 
@@ -73,35 +73,35 @@ Object {
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 181540,
+  "gasUsed": 181518,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ERC20 split V2 and V3, one hop, ADDRESS_THIS flag 1`] = `
 Object {
   "calldataByteLength": 1124,
-  "gasUsed": 181315,
+  "gasUsed": 181293,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, exactOut, one hop 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 196775,
+  "gasUsed": 196753,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ERC20 --> ETH split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1092,
-  "gasUsed": 189373,
+  "gasUsed": 189351,
 }
 `;
 
 exports[`Uniswap Gas Tests Mixing V2 and V3 with Universal Router. Split routes gas: ETH --> ERC20 split V2 and V3, one hop 1`] = `
 Object {
   "calldataByteLength": 1252,
-  "gasUsed": 196326,
+  "gasUsed": 196304,
 }
 `;
 
@@ -283,69 +283,69 @@ Object {
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 108487,
+  "gasUsed": 108465,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 260370,
+  "gasUsed": 260304,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactIn, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 181806,
+  "gasUsed": 181762,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, one hop 1`] = `
 Object {
   "calldataByteLength": 580,
-  "gasUsed": 116051,
+  "gasUsed": 116029,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, three hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 255381,
+  "gasUsed": 255315,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ERC20 gas: exactOut, one trade, two hops 1`] = `
 Object {
   "calldataByteLength": 612,
-  "gasUsed": 177415,
+  "gasUsed": 177371,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 124922,
+  "gasUsed": 124900,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ERC20 --> ETH gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 132558,
+  "gasUsed": 132536,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactIn swap 1`] = `
 Object {
   "calldataByteLength": 708,
-  "gasUsed": 218324,
+  "gasUsed": 218302,
 }
 `;
 
 exports[`Uniswap Gas Tests Trade on UniswapV3 with Universal Router. ETH --> ERC20 gas: exactOut swap 1`] = `
 Object {
   "calldataByteLength": 836,
-  "gasUsed": 127692,
+  "gasUsed": 127670,
 }
 `;

--- a/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
+++ b/test/integration-tests/gas-tests/__snapshots__/UniversalVSSwapRouter.gas.test.ts.snap
@@ -7,32 +7,32 @@ Object {
 }
 `;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1130193`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Max Approval Swap 1`] = `1129973`;
 
-exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1164802`;
+exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps Permit2 Sign Per Swap 1`] = `1164582`;
 
 exports[`Uniswap UX Tests gas: Comparisons Casual Swapper - 3 swaps SwapRouter02 1`] = `1124979`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3157789`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Max Approval Swap 1`] = `3157129`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3312224`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps Permit2 Sign Per Swap 1`] = `3311564`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper - 10 swaps SwapRouter02 1`] = `3195011`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4203204`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Max Approval Swap 1`] = `4202324`;
 
-exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4408406`;
+exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions Permit2 Sign Per Swap 1`] = `4407526`;
 
 exports[`Uniswap UX Tests gas: Comparisons Frequent Swapper across 3 swap router versions - 15 swaps across 3 versions SwapRouter02 1`] = `4282374`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `519476`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Max Approval Swap 1`] = `519388`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `519794`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap Permit2 Sign Per Swap 1`] = `519706`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Complex Swap SwapRouter02 1`] = `500008`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `304416`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Max Approval Swap 1`] = `304372`;
 
-exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `304352`;
+exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap Permit2 Sign Per Swap 1`] = `304308`;
 
 exports[`Uniswap UX Tests gas: Comparisons One Time Swapper - Simple Swap SwapRouter02 1`] = `270033`;


### PR DESCRIPTION
## What

Adds `V3_PROTOCOL_FEE_UPDATE` (0x17), the v3 sibling of `V4_PROTOCOL_FEE_UPDATE`. Input is `abi.encode(address pool)`. The router reads `UNISWAP_V3_FACTORY.owner()`, which is the fee adapter governance installed, and calls `triggerFeeUpdate(pool)` on it, pushing the pool's resolved protocol fee into its `slot0`.

## Why

Same motivation as the v4 poke: newly created pools initialize with no protocol fee, and the offchain keeper misses the busy window right after a launch. This lets the trading API activate the fee in the same transaction as a swap on a fresh pool. Mark Toda asked for both v3 and v4.

## Design

- The adapter is discovered onchain as the factory `owner()`; the router holds no adapter address and follows an ownership change automatically.
- Failure matches the other call-based commands: the poke's revert surfaces as `ExecutionFailed` unless `FLAG_ALLOW_REVERT` is set. With no adapter installed the call targets `address(0)` and is a no-op, so one route shape works on every chain.

This is stacked on the re-encode removal, which freed the bytecode it needs.

## Bytecode

| | Runtime | Free under 24,576 |
|---|---|---|
| drop-reencode PR | 24,243 | 333 |
| This PR | 24,428 | **148** |

## Testing

`V3ProtocolFeeUpdate.t.sol` with a mock factory whose `owner()` is a recording adapter: the poke reaches the adapter with the right pool and caller; a reverting adapter bubbles as `ExecutionFailed` and `FLAG_ALLOW_REVERT` continues; an unset owner is a no-op; a short input reverts `SliceOutOfBounds`.

`forge test --isolate` with `FORK_URL`: 168 passed. `yarn test:hardhat`: 190 passing (gas snapshots regenerated).

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## What
Adds `V3_PROTOCOL_FEE_UPDATE` (`0x17`), the v3 sibling of `V4_PROTOCOL_FEE_UPDATE`. Input is `abi.encode(address pool)`. The router reads `UNISWAP_V3_FACTORY.owner()`, which is the fee adapter governance installed, and calls `triggerFeeUpdate(pool)` on it, pushing the pool's resolved protocol fee into its `slot0`.
## Why
Same motivation as the v4 poke: newly created pools initialize with no protocol fee, and the offchain keeper misses the busy window right after a launch. This lets the trading API activate the fee in the same transaction as a swap on a fresh pool.
## Design
- The adapter is discovered onchain as the factory `owner()`; the router holds no adapter address and follows an ownership change automatically.
- Failure matches the other call-based commands: the poke's revert surfaces as `ExecutionFailed` unless `FLAG_ALLOW_REVERT` is set. With no adapter installed the call targets `address(0)` and is a no-op, so one route shape works on every chain.
This is stacked on the re-encode removal, which freed the bytecode it needs.
## Changes
- **`Commands.sol`**: Define `V3_PROTOCOL_FEE_UPDATE = 0x17`
- **`Dispatcher.sol`**: Import `IV3FeeAdapter` and `IUniswapV3Factory`; add the `0x17` branch that reads `factory.owner()` and calls `triggerFeeUpdate(pool)` with `checkInputLength` validation
- **`IV3FeeAdapter.sol`**: New interface with `triggerFeeUpdate(address pool)` — the permissionless entrypoint of the v3 fee adapter
- **`README.md`**: Add `V3_PROTOCOL_FEE_UPDATE` to the command table and document it alongside the v4 poke
## Bytecode
| | Runtime | Free under 24,576 |
|---|---|---|
| drop-reencode PR | 24,243 | 333 |
| This PR | 24,428 | **148** |
## Testing
`V3ProtocolFeeUpdate.t.sol` with a mock factory whose `owner()` is a recording adapter:
- The poke reaches the adapter with the right pool and caller
- A reverting adapter bubbles as `ExecutionFailed` and `FLAG_ALLOW_REVERT` continues
- An unset owner (`address(0)`) is a no-op
- A short input reverts `SliceOutOfBounds`
Gas snapshots regenerated — minor gas decreases across existing V3 swap paths (~22–44 gas) from branch restructuring.

</details>
<!-- claude-pr-description-end -->